### PR TITLE
fix: Push all docker tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,4 +52,4 @@ jobs:
           VERSION=$(./scripts/version.sh)
           IMAGE=ghcr.io/coder/envbuilder:$VERSION
           docker tag envbuilder:latest $IMAGE
-          docker push $IMAGE
+          docker push envbuilder --all-tags


### PR DESCRIPTION
The latest tag was not being pushed to the registry. This PR fixes that and pushes all tags.
Fixes #12 