### PR TITLE
fix: Iterate over Options and ContainerEnv maps in consistent order

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -495,9 +495,6 @@ func Run(ctx context.Context, options Options) error {
 				CacheTTL: time.Hour * 24 * 7,
 				CacheDir: options.BaseImageCacheDir,
 			},
-			// Ensures that the final layer has timestamps stripped.
-			// This can help with sourcing from a cache!
-			Reproducible:      true,
 			ForceUnpack:       true,
 			BuildArgs:         buildParams.BuildArgs,
 			CacheRepo:         options.CacheRepo,


### PR DESCRIPTION
This should fix random cache misses.

Also, remove `Reproducible` flag, which seems to cause an unexpected performance regression.