### PR TITLE
feat: Support alternate path for devcontainer.json file

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -111,10 +111,15 @@ type Options struct {
 	// It will override CacheRepo if both are specified.
 	LayerCacheDir string `env:"LAYER_CACHE_DIR"`
 
-	// DockerfilePath is a relative path to the workspace
-	// folder that will be used to build the workspace.
-	// This is an alternative to using a devcontainer
-	// that some might find simpler.
+	// DevcontainerJSONPath is a relative or absolute path to a
+	// devcontainer.json file. This can be used in cases where
+	// one wants to substitute an edited devcontainer.json file
+	// for the one that exists in the repo.
+	DevcontainerJSONPath string `env:"DEVCONTAINER_JSON_PATH"`
+
+	// DockerfilePath is a relative path to the Dockerfile that
+	// will be used to build the workspace. This is an alternative
+	// to using a devcontainer that some might find simpler.
 	DockerfilePath string `env:"DOCKERFILE_PATH"`
 
 	// DockerConfigBase64 is a base64 encoded Docker config
@@ -363,7 +368,13 @@ func Run(ctx context.Context, options Options) error {
 		// Only look for a devcontainer if a Dockerfile wasn't specified.
 		// devcontainer is a standard, so it's reasonable to be the default.
 		devcontainerDir := filepath.Join(options.WorkspaceFolder, ".devcontainer")
-		devcontainerPath := filepath.Join(devcontainerDir, "devcontainer.json")
+		devcontainerPath := options.DevcontainerJSONPath
+		if devcontainerPath == "" {
+			devcontainerPath = "devcontainer.json"
+		}
+		if !filepath.IsAbs(devcontainerPath) {
+			devcontainerPath = filepath.Join(devcontainerDir, devcontainerPath)
+		}
 		_, err := options.Filesystem.Stat(devcontainerPath)
 		if err == nil {
 			// We know a devcontainer exists.

--- a/envbuilder_test.go
+++ b/envbuilder_test.go
@@ -21,20 +21,22 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 func TestSystemOptions(t *testing.T) {
 	t.Parallel()
 	opts := map[string]string{
-		"INIT_SCRIPT":      "echo hello",
-		"CACHE_REPO":       "kylecarbs/testing",
-		"DOCKERFILE_PATH":  "Dockerfile",
-		"FALLBACK_IMAGE":   "ubuntu:latest",
-		"FORCE_SAFE":       "true",
-		"INSECURE":         "false",
-		"GIT_URL":          "https://github.com/coder/coder",
-		"WORKSPACE_FOLDER": "/workspaces/coder",
+		"INIT_SCRIPT":            "echo hello",
+		"CACHE_REPO":             "kylecarbs/testing",
+		"DEVCONTAINER_JSON_PATH": "/tmp/devcontainer.json",
+		"DOCKERFILE_PATH":        "Dockerfile",
+		"FALLBACK_IMAGE":         "ubuntu:latest",
+		"FORCE_SAFE":             "true",
+		"INSECURE":               "false",
+		"GIT_URL":                "https://github.com/coder/coder",
+		"WORKSPACE_FOLDER":       "/workspaces/coder",
 	}
 	env := envbuilder.OptionsFromEnv(func(s string) (string, bool) {
 		return opts[s], true
 	})
 	require.Equal(t, "echo hello", env.InitScript)
 	require.Equal(t, "kylecarbs/testing", env.CacheRepo)
+	require.Equal(t, "/tmp/devcontainer.json", env.DevcontainerJSONPath)
 	require.Equal(t, "Dockerfile", env.DockerfilePath)
 	require.Equal(t, "ubuntu:latest", env.FallbackImage)
 	require.True(t, env.ForceSafe)


### PR DESCRIPTION
I have a use case where I need to patch the `devcontainer.json` file that exists in the repo before running the build. This adds a `DEVCONTAINER_JSON_PATH` environment variable which can point to a different path to the `devcontainer.json` file. This allows an alternative `devcontainer.json` to be mounted into the container.

I'm open to suggestions of other ways to do this if anything comes to mind.