### PR TITLE
Add support for lifecycle scripts (postCreateCommand, etc)

### DIFF
--- a/devcontainer/devcontainer.go
+++ b/devcontainer/devcontainer.go
@@ -35,10 +35,18 @@ type Spec struct {
 	RemoteEnv  map[string]string `json:"remoteEnv"`
 	// Features is a map of feature names to feature configurations.
 	Features map[string]any `json:"features"`
+	LifecycleScripts
 
 	// Deprecated but still frequently used...
 	Dockerfile string `json:"dockerFile"`
 	Context    string `json:"context"`
+}
+
+type LifecycleScripts struct {
+	OnCreateCommand      LifecycleScript `json:"onCreateCommand"`
+	UpdateContentCommand LifecycleScript `json:"updateContentCommand"`
+	PostCreateCommand    LifecycleScript `json:"postCreateCommand"`
+	PostStartCommand     LifecycleScript `json:"postStartCommand"`
 }
 
 type BuildSpec struct {

--- a/devcontainer/script.go
+++ b/devcontainer/script.go
@@ -1,0 +1,102 @@
+package devcontainer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type LifecycleScript struct {
+	shellCommands    map[string]string
+	nonShellCommands map[string][]string
+}
+
+func (s *LifecycleScript) IsEmpty() bool {
+	return len(s.shellCommands) == 0 && len(s.nonShellCommands) == 0
+}
+
+func (s *LifecycleScript) UnmarshalJSON(data []byte) error {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch v := v.(type) {
+	case string:
+		s.shellCommands = map[string]string{
+			v: v,
+		}
+	case []any:
+		args, err := argsFromUntypedSlice(v)
+		if err != nil {
+			return err
+		}
+		desc := strings.Join(args, " ")
+		s.nonShellCommands = map[string][]string{
+			desc: args,
+		}
+	case map[string]any:
+		for desc, command := range v {
+			switch command := command.(type) {
+			case string:
+				if s.shellCommands == nil {
+					s.shellCommands = make(map[string]string, 1)
+				}
+				s.shellCommands[desc] = command
+			case []any:
+				args, err := argsFromUntypedSlice(command)
+				if err != nil {
+					return err
+				}
+				if s.nonShellCommands == nil {
+					s.nonShellCommands = make(map[string][]string, 1)
+				}
+				s.nonShellCommands[desc] = args
+			}
+		}
+	}
+	return nil
+}
+
+func argsFromUntypedSlice(args []any) ([]string, error) {
+	s := make([]string, 0, len(args))
+	for _, arg := range args {
+		arg, ok := arg.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid command arg with non-string type: %v", arg)
+		}
+		s = append(s, arg)
+	}
+	return s, nil
+}
+
+func (s *LifecycleScript) Execute(ctx context.Context) error {
+	var eg errgroup.Group
+	for desc, command := range s.shellCommands {
+		desc := desc
+		command := command
+		eg.Go(func() error {
+			if err := exec.CommandContext(ctx, "/bin/sh", "-c", command).Run(); err != nil {
+				return fmt.Errorf("lifecycle command %q failed: %v", desc, err)
+			}
+			return nil
+		})
+	}
+
+	for desc, command := range s.nonShellCommands {
+		desc := desc
+		command := command
+		eg.Go(func() error {
+			if err := exec.CommandContext(ctx, command[0], command[1:]...).Run(); err != nil {
+				return fmt.Errorf("lifecycle command %q failed: %v", desc, err)
+			}
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}

--- a/devcontainer/script_test.go
+++ b/devcontainer/script_test.go
@@ -1,0 +1,60 @@
+package devcontainer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want LifecycleScript
+	}{
+		{
+			name: "command string",
+			in:   `"echo hello"`,
+			want: LifecycleScript{
+				shellCommands: map[string]string{
+					"echo hello": "echo hello",
+				},
+			},
+		},
+		{
+			name: "command array",
+			in:   `["echo", "hello"]`,
+			want: LifecycleScript{
+				nonShellCommands: map[string][]string{
+					"echo hello": {"echo", "hello"},
+				},
+			},
+		},
+		{
+			name: "command map",
+			in:   `{"script 1": ["echo", "hello"], "script 2": ["echo", "world"], "script 3": "echo hello world"}`,
+			want: LifecycleScript{
+				shellCommands: map[string]string{
+					"script 3": "echo hello world",
+				},
+				nonShellCommands: map[string][]string{
+					"script 1": {"echo", "hello"},
+					"script 2": {"echo", "world"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got LifecycleScript
+			if err := json.Unmarshal([]byte(tt.in), &got); err != nil {
+				t.Fatal(err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
+	golang.org/x/sync v0.3.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
@@ -242,7 +243,6 @@ require (
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/oauth2 v0.9.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/term v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -364,9 +364,6 @@ func TestExportEnvFile(t *testing.T) {
 				"build": {
 					"dockerfile": "Dockerfile"
 				},
-				"build": {
-					"dockerfile": "Dockerfile"
-				},
 				"remoteEnv": {
 					"FROM_DEVCONTAINER_JSON": "bar"
 				}
@@ -394,9 +391,6 @@ func TestLifecycleScripts(t *testing.T) {
 		files: map[string]string{
 			".devcontainer/devcontainer.json": `{
 				"name": "Test",
-				"build": {
-					"dockerfile": "Dockerfile"
-				},
 				"build": {
 					"dockerfile": "Dockerfile"
 				},


### PR DESCRIPTION
Parse and execute the following "...Command" hooks:

* `onCreateCommand`
* `updateContentCommand`
* `postCreateCommand`
* `postStartCommand`

Closes: #34