### PR TITLE
fix: using multiple features and opts with spaces

### DIFF
--- a/devcontainer/devcontainer_test.go
+++ b/devcontainer/devcontainer_test.go
@@ -91,9 +91,9 @@ func TestCompileWithFeatures(t *testing.T) {
 
 	// We have to SHA because we get a different MD5 every time!
 	featureOneMD5 := md5.Sum([]byte(featureOne))
-	featureOneDir := fmt.Sprintf(".envbuilder/features/one-%x", featureOneMD5[:4])
+	featureOneDir := fmt.Sprintf("/.envbuilder/features/one-%x", featureOneMD5[:4])
 	featureTwoMD5 := md5.Sum([]byte(featureTwo))
-	featureTwoDir := fmt.Sprintf(".envbuilder/features/two-%x", featureTwoMD5[:4])
+	featureTwoDir := fmt.Sprintf("/.envbuilder/features/two-%x", featureTwoMD5[:4])
 
 	require.Equal(t, `FROM codercom/code-server:latest
 
@@ -105,7 +105,7 @@ RUN ./install.sh
 # Go potato - Example description!
 WORKDIR `+featureTwoDir+`
 ENV POTATO=example
-RUN VERSION=potato ./install.sh
+RUN VERSION="potato" ./install.sh
 USER 1000`, params.DockerfileContent)
 }
 

--- a/devcontainer/features/features.go
+++ b/devcontainer/features/features.go
@@ -179,7 +179,7 @@ func (s *Spec) Compile(options map[string]any) (string, error) {
 			// delete so we can check if there are any unknown options
 			delete(options, key)
 		}
-		runDirective = append(runDirective, fmt.Sprintf("%s=%s", convertOptionNameToEnv(key), strValue))
+		runDirective = append(runDirective, fmt.Sprintf(`%s="%s"`, convertOptionNameToEnv(key), strValue))
 	}
 	if len(options) > 0 {
 		return "", fmt.Errorf("unknown option: %v", options)

--- a/devcontainer/features/features_test.go
+++ b/devcontainer/features/features_test.go
@@ -111,6 +111,6 @@ func TestCompile(t *testing.T) {
 		}
 		directive, err := spec.Compile(nil)
 		require.NoError(t, err)
-		require.Equal(t, "WORKDIR /\nRUN FOO=bar ./install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nRUN FOO=\"bar\" ./install.sh", strings.TrimSpace(directive))
 	})
 }

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -61,7 +61,7 @@ const (
 	// MagicDir is where all envbuilder related files are stored.
 	// This is a special directory that must not be modified
 	// by the user or images.
-	MagicDir = ".envbuilder"
+	MagicDir = "/.envbuilder"
 )
 
 var (
@@ -304,7 +304,7 @@ func Run(ctx context.Context, options Options) error {
 		if err != nil {
 			return fmt.Errorf("parse docker config: %w", err)
 		}
-		err = os.WriteFile(filepath.Join("/", MagicDir, "config.json"), decoded, 0644)
+		err = os.WriteFile(filepath.Join(MagicDir, "config.json"), decoded, 0644)
 		if err != nil {
 			return fmt.Errorf("write docker config: %w", err)
 		}


### PR DESCRIPTION
https://github.com/coder/envbuilder/pull/64 broke building more than one feature in a dev container due to relative paths provided to `WORKDIR` causing the directory to be changed relative to previous `WORKDIR` directives (e.g. via previous features when multiple features are used), and meanwhile the `MagicDir` was being set to be a relative path. This PR fixes that issue by changing `MagicDir` to be an absolute path.

This PR also fixes an issue around not quoting feature option values which caused building dev containers that use feature option values containing spaces to fail.

An existing integration test around building a dev container with a feature was enhanced to exercise building multiple features that use spaces in their option values.