### PR TITLE
feature: add devcontainer to repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "envbuilder",
+    "image": "mcr.microsoft.com/devcontainers/go:0-1.20",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker": {}
+    }
+}


### PR DESCRIPTION
This PR adds a very basic dev container to the repo that can be used to build and test `envbuilder`.