### PR TITLE
feat: ensure _REMOTE_USER is set for feature install

### DIFF
--- a/devcontainer/features/features_test.go
+++ b/devcontainer/features/features_test.go
@@ -73,7 +73,7 @@ func TestCompile(t *testing.T) {
 	t.Run("UnknownOption", func(t *testing.T) {
 		t.Parallel()
 		spec := &features.Spec{}
-		_, err := spec.Compile(map[string]any{
+		_, err := spec.Compile("containerUser", "remoteUser", map[string]any{
 			"unknown": "value",
 		})
 		require.ErrorContains(t, err, "unknown option")
@@ -83,9 +83,9 @@ func TestCompile(t *testing.T) {
 		spec := &features.Spec{
 			Directory: "/",
 		}
-		directive, err := spec.Compile(nil)
+		directive, err := spec.Compile("containerUser", "remoteUser", nil)
 		require.NoError(t, err)
-		require.Equal(t, "WORKDIR /\nRUN ./install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nRUN _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
 	t.Run("ContainerEnv", func(t *testing.T) {
 		t.Parallel()
@@ -95,9 +95,9 @@ func TestCompile(t *testing.T) {
 				"FOO": "bar",
 			},
 		}
-		directive, err := spec.Compile(nil)
+		directive, err := spec.Compile("containerUser", "remoteUser", nil)
 		require.NoError(t, err)
-		require.Equal(t, "WORKDIR /\nENV FOO=bar\nRUN ./install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nENV FOO=bar\nRUN _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
 	t.Run("OptionsEnv", func(t *testing.T) {
 		t.Parallel()
@@ -109,8 +109,8 @@ func TestCompile(t *testing.T) {
 				},
 			},
 		}
-		directive, err := spec.Compile(nil)
+		directive, err := spec.Compile("containerUser", "remoteUser", nil)
 		require.NoError(t, err)
-		require.Equal(t, "WORKDIR /\nRUN FOO=\"bar\" ./install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nRUN FOO=\"bar\" _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
 }


### PR DESCRIPTION
The spec says we should be setting _REMOTE_USER, _CONTAINER_USER, _REMOTE_USER_HOME, and _CONTAINER_USER_HOME.
https://containers.dev/implementors/features/#user-env-var

The _REMOTE_USER is pretty easy for now, not sure about the other 3.