### PR TITLE
Support environment variables defined in containerEnv

### DIFF
--- a/devcontainer/devcontainer.go
+++ b/devcontainer/devcontainer.go
@@ -33,6 +33,7 @@ type Spec struct {
 	Build         BuildSpec         `json:"build"`
 	RemoteUser    string            `json:"remoteUser"`
 	ContainerUser string            `json:"containerUser"`
+	ContainerEnv  map[string]string `json:"containerEnv"`
 	RemoteEnv     map[string]string `json:"remoteEnv"`
 	// Features is a map of feature names to feature configurations.
 	Features map[string]any `json:"features"`
@@ -86,8 +87,10 @@ func (s Spec) HasDockerfile() bool {
 // be written to if one doesn't exist.
 func (s *Spec) Compile(fs billy.Filesystem, devcontainerDir, scratchDir, fallbackDockerfile string) (*Compiled, error) {
 	env := make([]string, 0)
-	for key, value := range s.RemoteEnv {
-		env = append(env, key+"="+value)
+	for _, envMap := range []map[string]string{s.ContainerEnv, s.RemoteEnv} {
+		for key, value := range envMap {
+			env = append(env, key+"="+value)
+		}
 	}
 	params := &Compiled{
 		User: s.ContainerUser,

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -743,8 +743,8 @@ func Run(ctx context.Context, options Options) error {
 
 				configFile.Config.User = container.RemoteUser
 			}
-			if container.RemoteEnv != nil {
-				for key, value := range container.RemoteEnv {
+			for _, env := range []map[string]string{container.ContainerEnv, container.RemoteEnv} {
+				for key, value := range env {
 					os.Setenv(key, value)
 					exportEnv(key, value)
 				}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -409,8 +409,11 @@ func TestExportEnvFile(t *testing.T) {
 				"build": {
 					"dockerfile": "Dockerfile"
 				},
+				"containerEnv": {
+					"FROM_CONTAINER_ENV": "bar"
+				},
 				"remoteEnv": {
-					"FROM_DEVCONTAINER_JSON": "bar"
+					"FROM_REMOTE_ENV": "baz"
 				}
 			}`,
 			".devcontainer/Dockerfile": "FROM alpine:latest\nENV FROM_DOCKERFILE=foo",
@@ -425,7 +428,8 @@ func TestExportEnvFile(t *testing.T) {
 	output := execContainer(t, ctr, "cat /env")
 	require.Contains(t, strings.TrimSpace(output),
 		`FROM_DOCKERFILE=foo
-FROM_DEVCONTAINER_JSON=bar`)
+FROM_CONTAINER_ENV=bar
+FROM_REMOTE_ENV=baz`)
 }
 
 func TestLifecycleScripts(t *testing.T) {


### PR DESCRIPTION
envbuilder only looked at `remoteEnv`, but it should also define variables from `containerEnv`. `containerEnv` is recommended over `remoteEnv` by the spec:

> We recommend using containerEnv (over remoteEnv) as much as possible
> since it allows all processes to see the variable and isn’t
> client-specific.