### PR TITLE
Support local features provided inside .devcontainer dir

### DIFF
--- a/devcontainer/features/features_test.go
+++ b/devcontainer/features/features_test.go
@@ -17,7 +17,7 @@ func TestExtract(t *testing.T) {
 		registry := registrytest.New(t)
 		ref := registrytest.WriteContainer(t, registry, "coder/test:latest", "some/type", nil)
 		fs := memfs.New()
-		_, err := features.Extract(fs, "/", ref)
+		_, err := features.Extract(fs, "", "/", ref)
 		require.ErrorContains(t, err, "no tar layer found")
 	})
 	t.Run("MissingInstallScript", func(t *testing.T) {
@@ -27,7 +27,7 @@ func TestExtract(t *testing.T) {
 			"devcontainer-feature.json": "{}",
 		})
 		fs := memfs.New()
-		_, err := features.Extract(fs, "/", ref)
+		_, err := features.Extract(fs, "", "/", ref)
 		require.ErrorContains(t, err, "install.sh")
 	})
 	t.Run("MissingFeatureFile", func(t *testing.T) {
@@ -37,7 +37,7 @@ func TestExtract(t *testing.T) {
 			"install.sh": "hey",
 		})
 		fs := memfs.New()
-		_, err := features.Extract(fs, "/", ref)
+		_, err := features.Extract(fs, "", "/", ref)
 		require.ErrorContains(t, err, "devcontainer-feature.json")
 	})
 	t.Run("MissingFeatureProperties", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestExtract(t *testing.T) {
 			"devcontainer-feature.json": features.Spec{},
 		})
 		fs := memfs.New()
-		_, err := features.Extract(fs, "/", ref)
+		_, err := features.Extract(fs, "", "/", ref)
 		require.ErrorContains(t, err, "id is required")
 	})
 	t.Run("Success", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestExtract(t *testing.T) {
 			},
 		})
 		fs := memfs.New()
-		_, err := features.Extract(fs, "/", ref)
+		_, err := features.Extract(fs, "", "/", ref)
 		require.NoError(t, err)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-isatty v0.0.19
+	github.com/otiai10/copy v1.14.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
@@ -186,7 +187,6 @@ require (
 	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
-	github.com/otiai10/copy v1.12.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -725,8 +725,8 @@ github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuh
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
-github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=
-github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=


### PR DESCRIPTION
This allows features to be provided inside the `.devcontainer` directory rather than downloaded from a registry, matching the behavior of the official devcontainer tooling.

For example, Kubernetes tooling generates a devcontainer.json containing:

    "features": {
        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
            "enableNonRootDocker": "true",
            "moby": "true"
        },
        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
        "./local-features/copy-kube-config": {}
    },

cc @coryb