### PR TITLE
Add registry mirror environment variable option

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -656,6 +656,7 @@ func Run(ctx context.Context, options Options) error {
 				Insecure:      options.Insecure,
 				InsecurePull:  options.Insecure,
 				SkipTLSVerify: options.Insecure,
+				RegistryMirrors: strings.Split(os.Getenv("KANIKO_REGISTRY_MIRROR"), ";"),
 			},
 			SrcContext: buildParams.BuildContext,
 		})

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -625,9 +625,9 @@ func Run(ctx context.Context, options Options) error {
 
 		endStage := startStage("🏗️ Building image...")
 		// At this point we have all the context, we can now build!
-		var registry_mirror []string = nil
+		registryMirror := []string{}
 		if val, ok := os.LookupEnv("KANIKO_REGISTRY_MIRROR"); ok {
-			registry_mirror = strings.Split(val, ";")
+			registryMirror = strings.Split(val, ";")
 		}
 		image, err := executor.DoBuild(&config.KanikoOptions{
 			// Boilerplate!
@@ -664,7 +664,7 @@ func Run(ctx context.Context, options Options) error {
 				// https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#flag---registry-mirror
 				// Related to PR #114
 				// https://github.com/coder/envbuilder/pull/114
-				RegistryMirrors: registry_mirror,
+				RegistryMirrors: registryMirror,
 			},
 			SrcContext: buildParams.BuildContext,
 		})

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -625,6 +625,10 @@ func Run(ctx context.Context, options Options) error {
 
 		endStage := startStage("🏗️ Building image...")
 		// At this point we have all the context, we can now build!
+		var registry_mirror []string = nil
+		if val, ok := os.LookupEnv("KANIKO_REGISTRY_MIRROR"); ok {
+			registry_mirror = strings.Split(val, ";")
+		}
 		image, err := executor.DoBuild(&config.KanikoOptions{
 			// Boilerplate!
 			CustomPlatform:    platforms.Format(platforms.Normalize(platforms.DefaultSpec())),
@@ -660,7 +664,7 @@ func Run(ctx context.Context, options Options) error {
 				// https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#flag---registry-mirror
 				// Related to PR #114
 				// https://github.com/coder/envbuilder/pull/114
-				RegistryMirrors: strings.Split(os.Getenv("·"), ";"),
+				RegistryMirrors: registry_mirror,
 			},
 			SrcContext: buildParams.BuildContext,
 		})

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -656,7 +656,11 @@ func Run(ctx context.Context, options Options) error {
 				Insecure:      options.Insecure,
 				InsecurePull:  options.Insecure,
 				SkipTLSVerify: options.Insecure,
-				RegistryMirrors: strings.Split(os.Getenv("KANIKO_REGISTRY_MIRROR"), ";"),
+				// Enables registry mirror features in Kaniko, see more in link below
+				// https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#flag---registry-mirror
+				// Related to PR #114
+				// https://github.com/coder/envbuilder/pull/114
+				RegistryMirrors: strings.Split(os.Getenv("·"), ";"),
 			},
 			SrcContext: buildParams.BuildContext,
 		})


### PR DESCRIPTION
Add `KANIKO_REGISTRY_MIRROR` environment variable that can set mirrors for docker hub. 
Useful when rate limited by docker hub.