### PR TITLE
Support providing feature directories in build contexts

### DIFF
--- a/devcontainer/devcontainer_test.go
+++ b/devcontainer/devcontainer_test.go
@@ -87,7 +87,7 @@ func TestCompileWithFeatures(t *testing.T) {
 	dc, err := devcontainer.Parse([]byte(raw))
 	require.NoError(t, err)
 	fs := memfs.New()
-	params, err := dc.Compile(fs, "", magicDir, "", "")
+	params, err := dc.Compile(fs, "", magicDir, "", "", false)
 	require.NoError(t, err)
 
 	// We have to SHA because we get a different MD5 every time!
@@ -118,7 +118,7 @@ func TestCompileDevContainer(t *testing.T) {
 		dc := &devcontainer.Spec{
 			Image: "codercom/code-server:latest",
 		}
-		params, err := dc.Compile(fs, "", magicDir, "", "")
+		params, err := dc.Compile(fs, "", magicDir, "", "", false)
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join(magicDir, "Dockerfile"), params.DockerfilePath)
 		require.Equal(t, magicDir, params.BuildContext)
@@ -144,7 +144,7 @@ func TestCompileDevContainer(t *testing.T) {
 		_, err = io.WriteString(file, "FROM ubuntu")
 		require.NoError(t, err)
 		_ = file.Close()
-		params, err := dc.Compile(fs, dcDir, magicDir, "", "/var/workspace")
+		params, err := dc.Compile(fs, dcDir, magicDir, "", "/var/workspace", false)
 		require.NoError(t, err)
 		require.Equal(t, "ARG1=value1", params.BuildArgs[0])
 		require.Equal(t, "ARG2=workspace", params.BuildArgs[1])

--- a/devcontainer/features/features_test.go
+++ b/devcontainer/features/features_test.go
@@ -73,7 +73,7 @@ func TestCompile(t *testing.T) {
 	t.Run("UnknownOption", func(t *testing.T) {
 		t.Parallel()
 		spec := &features.Spec{}
-		_, err := spec.Compile("containerUser", "remoteUser", map[string]any{
+		_, err := spec.Compile("test", "containerUser", "remoteUser", false, map[string]any{
 			"unknown": "value",
 		})
 		require.ErrorContains(t, err, "unknown option")
@@ -83,7 +83,7 @@ func TestCompile(t *testing.T) {
 		spec := &features.Spec{
 			Directory: "/",
 		}
-		directive, err := spec.Compile("containerUser", "remoteUser", nil)
+		directive, err := spec.Compile("test", "containerUser", "remoteUser", false, nil)
 		require.NoError(t, err)
 		require.Equal(t, "WORKDIR /\nRUN _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
@@ -95,7 +95,7 @@ func TestCompile(t *testing.T) {
 				"FOO": "bar",
 			},
 		}
-		directive, err := spec.Compile("containerUser", "remoteUser", nil)
+		directive, err := spec.Compile("test", "containerUser", "remoteUser", false, nil)
 		require.NoError(t, err)
 		require.Equal(t, "WORKDIR /\nENV FOO=bar\nRUN _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
@@ -109,8 +109,17 @@ func TestCompile(t *testing.T) {
 				},
 			},
 		}
-		directive, err := spec.Compile("containerUser", "remoteUser", nil)
+		directive, err := spec.Compile("test", "containerUser", "remoteUser", false, nil)
 		require.NoError(t, err)
 		require.Equal(t, "WORKDIR /\nRUN FOO=\"bar\" _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
+	})
+	t.Run("BuildContext", func(t *testing.T) {
+		t.Parallel()
+		spec := &features.Spec{
+			Directory: "/",
+		}
+		directive, err := spec.Compile("test", "containerUser", "remoteUser", true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "WORKDIR /envbuilder-features/test\nRUN --mount=type=bind,from=test,target=/envbuilder-features/test,rw _CONTAINER_USER=\"containerUser\" _REMOTE_USER=\"remoteUser\" ./install.sh", strings.TrimSpace(directive))
 	})
 }

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -460,7 +460,7 @@ func Run(ctx context.Context, options Options) error {
 					logf(codersdk.LogLevelInfo, "No Dockerfile or image specified; falling back to the default image...")
 					fallbackDockerfile = defaultParams.DockerfilePath
 				}
-				buildParams, err = devContainer.Compile(options.Filesystem, devcontainerDir, MagicDir, fallbackDockerfile, options.WorkspaceFolder)
+				buildParams, err = devContainer.Compile(options.Filesystem, devcontainerDir, MagicDir, fallbackDockerfile, options.WorkspaceFolder, false)
 				if err != nil {
 					return fmt.Errorf("compile devcontainer.json: %w", err)
 				}


### PR DESCRIPTION
When running a build within envbuilder, files created on the filesystem by this Go code are available at the same paths within the container build process. However, if external code calls into the `devcontainer` package to produce a Dockerfile to use for a non-kaniko-based build, the resulting Dockerfile needs to mount the feature directories into the relevant RUN stages in order to access the feature install script and associated files.