### PR TITLE
Keep readonly-volume-mounted config.json

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -772,9 +772,11 @@ func Run(ctx context.Context, options Options) error {
 	unsetOptionsEnv()
 
 	// Remove the Docker config secret file!
-	err = os.Remove(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json"))
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove docker config: %w", err)
+	if options.DockerConfigBase64 != "" {
+		err = os.Remove(filepath.Join(MagicDir, "config.json"))
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove docker config: %w", err)
+		}
 	}
 
 	environ, err := os.ReadFile("/etc/environment")


### PR DESCRIPTION
Fixes #104.

# Bug description

The config.json deletion code
https://github.com/coder/envbuilder/blob/8962d96602e9e46eee01cead2bc0670f999116ca/envbuilder.go#L775
seems intended to delete previously generated temporary one.
https://github.com/coder/envbuilder/blob/8962d96602e9e46eee01cead2bc0670f999116ca/envbuilder.go#L314

But in case config.json file is volume mounted with read-only mode on Docker or Kubernetes, the deletion fails with `error: remove docker config: remove /.envbuilder/config.json: device or resource busy`.

# Bug fix

Delete config.json only if it is generated from `DOCKER_CONFIG_BASE64` environment variable.

# Validation

Execute the following commands, and a deno devcontainer will run without errors.

```shell
echo '{}' > config.json
docker run --rm -it -e GIT_URL=https://github.com/denoland/deno -e INIT_SCRIPT=bash -v ./config.json:/.envbuilder/config.json:ro envbuilder:latest
```