### PR TITLE
feat: locate devcontainer.json in multiple places

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1195,7 +1195,7 @@ func (fs *osfsWithChmod) Chmod(name string, mode os.FileMode) error {
 }
 
 func findDevcontainerJSON(options Options) (string, string) {
-	// 0. Check provided options
+	// 0. Check provided options.
 	if options.DevcontainerDir != "" || options.DevcontainerJSONPath != "" {
 		// Locate .devcontainer directory.
 		devcontainerDir := options.DevcontainerDir
@@ -1226,9 +1226,21 @@ func findDevcontainerJSON(options Options) (string, string) {
 		return devcontainerDir, devcontainerPath
 	}
 
-	// 1. Check `options.WorkspaceFolder`/.devcontainer/devcontainer.json
-	// 2. Check `options.WorkspaceFolder`/devcontainer.json
-	// 3. Check every folder: `options.WorkspaceFolder`/<folder>/devcontainer.json
+	// 1. Check `options.WorkspaceFolder`/.devcontainer/devcontainer.json.
+	location := filepath.Join(options.WorkspaceFolder, ".devcontainer", "devcontainer.json")
+	_, err := options.Filesystem.Stat(location)
+	if err == nil {
+		return filepath.Dir(location), location
+	}
+
+	// 2. Check `options.WorkspaceFolder`/devcontainer.json.
+	location = filepath.Join(options.WorkspaceFolder, "devcontainer.json")
+	_, err = options.Filesystem.Stat(location)
+	if err == nil {
+		return filepath.Dir(location), location
+	}
+
+	// 3. Check every folder: `options.WorkspaceFolder`/<folder>/devcontainer.json.
 
 	panic("not implemented yet")
 }

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -118,8 +118,8 @@ type Options struct {
 	// DevcontainerDir is a path to the folder containing
 	// the devcontainer.json file that will be used to build the
 	// workspace and can either be an absolute path or a path
-	// relative to the workspace folder.
-	// If not provided, it defaults to `.devcontainer`.
+	// relative to the workspace folder. If not provided, defaults to
+	// `.devcontainer`.
 	DevcontainerDir string `env:"DEVCONTAINER_DIR"`
 
 	// DevcontainerJSONPath is a path to a devcontainer.json file
@@ -1197,9 +1197,8 @@ func (fs *osfsWithChmod) Chmod(name string, mode os.FileMode) error {
 }
 
 func findDevcontainerJSON(options Options) (string, string, error) {
-	// 0. Check provided options.
+	// 0. Check if custom devcontainer directory or path is provided.
 	if options.DevcontainerDir != "" || options.DevcontainerJSONPath != "" {
-		// Locate .devcontainer directory.
 		devcontainerDir := options.DevcontainerDir
 		if devcontainerDir == "" {
 			devcontainerDir = ".devcontainer"
@@ -1209,14 +1208,11 @@ func findDevcontainerJSON(options Options) (string, string, error) {
 			devcontainerDir = filepath.Join(options.WorkspaceFolder, devcontainerDir)
 		}
 
-		// Locate devcontainer.json manifest.
-		devcontainerPath := options.DevcontainerJSONPath
-
 		// An absolute location always takes a precedence.
+		devcontainerPath := options.DevcontainerJSONPath
 		if filepath.IsAbs(devcontainerPath) {
 			return options.DevcontainerJSONPath, devcontainerDir, nil
 		}
-
 		// If an override is not provided, assume it is just `devcontainer.json`.
 		if devcontainerPath == "" {
 			devcontainerPath = "devcontainer.json"
@@ -1230,15 +1226,13 @@ func findDevcontainerJSON(options Options) (string, string, error) {
 
 	// 1. Check `options.WorkspaceFolder`/.devcontainer/devcontainer.json.
 	location := filepath.Join(options.WorkspaceFolder, ".devcontainer", "devcontainer.json")
-	_, err := options.Filesystem.Stat(location)
-	if err == nil {
+	if _, err := options.Filesystem.Stat(location); err == nil {
 		return location, filepath.Dir(location), nil
 	}
 
 	// 2. Check `options.WorkspaceFolder`/devcontainer.json.
 	location = filepath.Join(options.WorkspaceFolder, "devcontainer.json")
-	_, err = options.Filesystem.Stat(location)
-	if err == nil {
+	if _, err := options.Filesystem.Stat(location); err == nil {
 		return location, filepath.Dir(location), nil
 	}
 
@@ -1258,8 +1252,7 @@ func findDevcontainerJSON(options Options) (string, string, error) {
 		}
 
 		location := filepath.Join(devcontainerDir, fileInfo.Name(), "devcontainer.json")
-		_, err := options.Filesystem.Stat(location)
-		if err != nil {
+		if _, err := options.Filesystem.Stat(location); err != nil {
 			logf(codersdk.LogLevelDebug, `stat %s failed: %s`, location, err.Error())
 			continue
 		}

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -427,9 +427,11 @@ func Run(ctx context.Context, options Options) error {
 	if options.DockerfilePath == "" {
 		// Only look for a devcontainer if a Dockerfile wasn't specified.
 		// devcontainer is a standard, so it's reasonable to be the default.
-		devcontainerPath, devcontainerDir := findDevcontainerJSON(options)
-		_, err := options.Filesystem.Stat(devcontainerPath)
-		if err == nil {
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(options)
+		if err != nil {
+			logf(codersdk.LogLevelError, "Failed to locate devcontainer.json: %s", err.Error())
+			logf(codersdk.LogLevelError, "Falling back to the default image...")
+		} else {
 			// We know a devcontainer exists.
 			// Let's parse it and use it!
 			file, err := options.Filesystem.Open(devcontainerPath)
@@ -1194,7 +1196,7 @@ func (fs *osfsWithChmod) Chmod(name string, mode os.FileMode) error {
 	return os.Chmod(name, mode)
 }
 
-func findDevcontainerJSON(options Options) (string, string) {
+func findDevcontainerJSON(options Options) (string, string, error) {
 	// 0. Check provided options.
 	if options.DevcontainerDir != "" || options.DevcontainerJSONPath != "" {
 		// Locate .devcontainer directory.
@@ -1212,7 +1214,7 @@ func findDevcontainerJSON(options Options) (string, string) {
 
 		// An absolute location always takes a precedence.
 		if filepath.IsAbs(devcontainerPath) {
-			return options.DevcontainerJSONPath, devcontainerDir
+			return options.DevcontainerJSONPath, devcontainerDir, nil
 		}
 
 		// If an override is not provided, assume it is just `devcontainer.json`.
@@ -1223,24 +1225,47 @@ func findDevcontainerJSON(options Options) (string, string) {
 		if !filepath.IsAbs(devcontainerPath) {
 			devcontainerPath = filepath.Join(devcontainerDir, devcontainerPath)
 		}
-		return devcontainerPath, devcontainerDir
+		return devcontainerPath, devcontainerDir, nil
 	}
 
 	// 1. Check `options.WorkspaceFolder`/.devcontainer/devcontainer.json.
 	location := filepath.Join(options.WorkspaceFolder, ".devcontainer", "devcontainer.json")
 	_, err := options.Filesystem.Stat(location)
 	if err == nil {
-		return location, filepath.Dir(location)
+		return location, filepath.Dir(location), nil
 	}
 
 	// 2. Check `options.WorkspaceFolder`/devcontainer.json.
 	location = filepath.Join(options.WorkspaceFolder, "devcontainer.json")
 	_, err = options.Filesystem.Stat(location)
 	if err == nil {
-		return location, filepath.Dir(location)
+		return location, filepath.Dir(location), nil
 	}
 
-	// 3. Check every folder: `options.WorkspaceFolder`/<folder>/devcontainer.json.
+	// 3. Check every folder: `options.WorkspaceFolder`/.devcontainer/<folder>/devcontainer.json.
+	devcontainerDir := filepath.Join(options.WorkspaceFolder, ".devcontainer")
 
-	panic("not implemented yet")
+	fileInfos, err := options.Filesystem.ReadDir(devcontainerDir)
+	if err != nil {
+		return "", "", err
+	}
+
+	logf := options.Logger
+	for _, fileInfo := range fileInfos {
+		if !fileInfo.IsDir() {
+			logf(codersdk.LogLevelDebug, `%s is a file`, fileInfo.Name())
+			continue
+		}
+
+		location := filepath.Join(devcontainerDir, fileInfo.Name(), "devcontainer.json")
+		_, err := options.Filesystem.Stat(location)
+		if err != nil {
+			logf(codersdk.LogLevelDebug, `stat %s failed: %s`, location, err.Error())
+			continue
+		}
+
+		return location, filepath.Dir(location), nil
+	}
+
+	return "", "", errors.New("can't find devcontainer.json, is it a correct spec?")
 }

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1223,21 +1223,21 @@ func findDevcontainerJSON(options Options) (string, string) {
 		if !filepath.IsAbs(devcontainerPath) {
 			devcontainerPath = filepath.Join(devcontainerDir, devcontainerPath)
 		}
-		return devcontainerDir, devcontainerPath
+		return devcontainerPath, devcontainerDir
 	}
 
 	// 1. Check `options.WorkspaceFolder`/.devcontainer/devcontainer.json.
 	location := filepath.Join(options.WorkspaceFolder, ".devcontainer", "devcontainer.json")
 	_, err := options.Filesystem.Stat(location)
 	if err == nil {
-		return filepath.Dir(location), location
+		return location, filepath.Dir(location)
 	}
 
 	// 2. Check `options.WorkspaceFolder`/devcontainer.json.
 	location = filepath.Join(options.WorkspaceFolder, "devcontainer.json")
 	_, err = options.Filesystem.Stat(location)
 	if err == nil {
-		return filepath.Dir(location), location
+		return location, filepath.Dir(location)
 	}
 
 	// 3. Check every folder: `options.WorkspaceFolder`/<folder>/devcontainer.json.

--- a/envbuilder_internal_test.go
+++ b/envbuilder_internal_test.go
@@ -1,0 +1,154 @@
+package envbuilder
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindDevcontainerJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty filesystem", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+
+		// when
+		_, _, err := findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+		})
+
+		// then
+		require.Error(t, err)
+	})
+
+	t.Run("devcontainers.json is missing", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace/.devcontainer", 0600)
+		require.NoError(t, err)
+
+		// when
+		_, _, err = findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+		})
+
+		// then
+		require.Error(t, err)
+	})
+
+	t.Run("default configuration", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace/.devcontainer", 0600)
+		require.NoError(t, err)
+		fs.Create("/workspace/.devcontainer/devcontainer.json")
+
+		// when
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "/workspace/.devcontainer/devcontainer.json", devcontainerPath)
+		assert.Equal(t, "/workspace/.devcontainer", devcontainerDir)
+	})
+
+	t.Run("overridden .devcontainer directory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace/experimental-devcontainer", 0600)
+		require.NoError(t, err)
+		fs.Create("/workspace/experimental-devcontainer/devcontainer.json")
+
+		// when
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+			DevcontainerDir: "experimental-devcontainer",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "/workspace/experimental-devcontainer/devcontainer.json", devcontainerPath)
+		assert.Equal(t, "/workspace/experimental-devcontainer", devcontainerDir)
+	})
+
+	t.Run("overridden devcontainer.json path", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace/.devcontainer", 0600)
+		require.NoError(t, err)
+		fs.Create("/workspace/.devcontainer/experimental.json")
+
+		// when
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(Options{
+			Filesystem:           fs,
+			WorkspaceFolder:      "/workspace",
+			DevcontainerJSONPath: "experimental.json",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "/workspace/.devcontainer/experimental.json", devcontainerPath)
+		assert.Equal(t, "/workspace/.devcontainer", devcontainerDir)
+	})
+
+	t.Run("devcontainer.json in workspace root", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace", 0600)
+		require.NoError(t, err)
+		fs.Create("/workspace/devcontainer.json")
+
+		// when
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "/workspace/devcontainer.json", devcontainerPath)
+		assert.Equal(t, "/workspace", devcontainerDir)
+	})
+
+	t.Run("devcontainer.json in subfolder of .devcontainer", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fs := memfs.New()
+		err := fs.MkdirAll("/workspace/.devcontainer/sample", 0600)
+		require.NoError(t, err)
+		fs.Create("/workspace/.devcontainer/sample/devcontainer.json")
+
+		// when
+		devcontainerPath, devcontainerDir, err := findDevcontainerJSON(Options{
+			Filesystem:      fs,
+			WorkspaceFolder: "/workspace",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "/workspace/.devcontainer/sample/devcontainer.json", devcontainerPath)
+		assert.Equal(t, "/workspace/.devcontainer/sample", devcontainerDir)
+	})
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -279,13 +279,13 @@ func TestBuildFromDevcontainerInSubfolder(t *testing.T) {
 	// Ensures that a Git repository with a devcontainer.json is cloned and built.
 	url := createGitServer(t, gitServerOptions{
 		files: map[string]string{
-			"./devcontainer/subfolder/devcontainer.json": `{
+			".devcontainer/subfolder/devcontainer.json": `{
 				"name": "Test",
 				"build": {
 					"dockerfile": "Dockerfile"
 				},
 			}`,
-			"Dockerfile": "FROM ubuntu",
+			".devcontainer/subfolder/Dockerfile": "FROM ubuntu",
 		},
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -273,6 +273,29 @@ func TestBuildFromDevcontainerInCustomPath(t *testing.T) {
 	require.Equal(t, "hello", strings.TrimSpace(output))
 }
 
+func TestBuildFromDevcontainerInSubfolder(t *testing.T) {
+	t.Parallel()
+
+	// Ensures that a Git repository with a devcontainer.json is cloned and built.
+	url := createGitServer(t, gitServerOptions{
+		files: map[string]string{
+			"./devcontainer/subfolder/devcontainer.json": `{
+				"name": "Test",
+				"build": {
+					"dockerfile": "Dockerfile"
+				},
+			}`,
+			"Dockerfile": "FROM ubuntu",
+		},
+	})
+	ctr, err := runEnvbuilder(t, options{env: []string{
+		"GIT_URL=" + url,
+	}})
+	require.NoError(t, err)
+
+	output := execContainer(t, ctr, "echo hello")
+	require.Equal(t, "hello", strings.TrimSpace(output))
+}
 func TestBuildFromDevcontainerInRoot(t *testing.T) {
 	t.Parallel()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -273,6 +273,30 @@ func TestBuildFromDevcontainerInCustomPath(t *testing.T) {
 	require.Equal(t, "hello", strings.TrimSpace(output))
 }
 
+func TestBuildFromDevcontainerInRoot(t *testing.T) {
+	t.Parallel()
+
+	// Ensures that a Git repository with a devcontainer.json is cloned and built.
+	url := createGitServer(t, gitServerOptions{
+		files: map[string]string{
+			"devcontainer.json": `{
+				"name": "Test",
+				"build": {
+					"dockerfile": "Dockerfile"
+				},
+			}`,
+			"Dockerfile": "FROM ubuntu",
+		},
+	})
+	ctr, err := runEnvbuilder(t, options{env: []string{
+		"GIT_URL=" + url,
+	}})
+	require.NoError(t, err)
+
+	output := execContainer(t, ctr, "echo hello")
+	require.Equal(t, "hello", strings.TrimSpace(output))
+}
+
 func TestBuildCustomCertificates(t *testing.T) {
 	srv := httptest.NewTLSServer(createGitHandler(t, gitServerOptions{
 		files: map[string]string{


### PR DESCRIPTION
Fixes: https://github.com/coder/envbuilder/issues/116

This PR extends the logic responsible for locating the `devcontainer.json` manifest to check in [multiple locations](https://containers.dev/implementors/spec/#devcontainerjson).