### PR TITLE
chore: add Makefile and local registry cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,4 +48,4 @@ jobs:
           go-version: "~1.21"
 
       - name: Test
-        run: go test ./...
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 scripts/envbuilder-*
+.registry-cache

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOARCH := $(shell go env GOARCH)
+PWD=$(shell pwd)
 
 develop:
 	./scripts/develop.sh
@@ -11,15 +12,19 @@ test: test-registry test-images
 	go test -count=1 ./...
 
 # Starts a local Docker registry on port 5000 with a local disk cache.
-test-registry:
-	curl -fsSL http://localhost:5000/v2/_catalog || \
-	docker run -d -p 5000:5000 --name envbuilder-registry --volume $(pwd)/.registry-cache:/var/lib/registry registry:2
+.PHONY: test-registry
+test-registry: .registry-cache
+	if [ ! curl -fsSL http://localhost:5000/v2/_catalog >/dev/null 2>&1 ]; then \
+		docker rm -f envbuilder-registry; \
+		docker run -d -p 5000:5000 --name envbuilder-registry --volume $(PWD)/.registry-cache:/var/lib/registry registry:2; \
+	fi
 
-# 
+# Pulls images referenced in integration tests and pushes them to the local cache.
+.PHONY: test-images
 test-images: .registry-cache .registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine .registry-cache/docker/registry/v2/repositories/envbuilder-test-ubuntu
 
 .registry-cache:
-	mkdir -p .registry-cache
+	mkdir -p .registry-cache && chmod -R ag+w .registry-cache
 
 .registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine:
 	docker pull alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+GOARCH := $(shell go env GOARCH)
+
+develop:
+	./scripts/develop.sh
+
+build: scripts/envbuilder-$(GOARCH)
+	./scripts/build.sh
+
+.PHONY: test
+test: test-registry test-images
+	go test -count=1 ./...
+
+# Starts a local Docker registry on port 5000 with a local disk cache.
+test-registry:
+	curl -fsSL http://localhost:5000/v2/_catalog || \
+	docker run -d -p 5000:5000 --name envbuilder-registry --volume $(pwd)/.registry-cache:/var/lib/registry registry:2
+
+# 
+test-images: .registry-cache .registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine .registry-cache/docker/registry/v2/repositories/envbuilder-test-ubuntu
+
+.registry-cache:
+	mkdir -p .registry-cache
+
+.registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine:
+	docker pull alpine:latest
+	docker tag alpine:latest localhost:5000/envbuilder-test-alpine:latest
+	docker push localhost:5000/envbuilder-test-alpine:latest
+
+.registry-cache/docker/registry/v2/repositories/envbuilder-test-ubuntu:
+	docker pull ubuntu:latest
+	docker tag ubuntu:latest localhost:5000/envbuilder-test-ubuntu:latest
+	docker push localhost:5000/envbuilder-test-ubuntu:latest

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,8 @@ test-images: .registry-cache .registry-cache/docker/registry/v2/repositories/env
 	docker pull ubuntu:latest
 	docker tag ubuntu:latest localhost:5000/envbuilder-test-ubuntu:latest
 	docker push localhost:5000/envbuilder-test-ubuntu:latest
+
+.registry-cache/docker/registry/v2/repositories/envbuilder-test-codercom-code-server:
+	docker pull codercom/code-server:latest
+	docker tag codercom/code-server:latest localhost:5000/envbuilder-test-codercom-code-server:latest
+	docker push localhost:5000/envbuilder-test-codercom-code-server:latest

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-registry: .registry-cache
 
 # Pulls images referenced in integration tests and pushes them to the local cache.
 .PHONY: test-images
-test-images: .registry-cache .registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine .registry-cache/docker/registry/v2/repositories/envbuilder-test-ubuntu
+test-images: .registry-cache .registry-cache/docker/registry/v2/repositories/envbuilder-test-alpine .registry-cache/docker/registry/v2/repositories/envbuilder-test-ubuntu .registry-cache/docker/registry/v2/repositories/envbuilder-test-codercom-code-server
 
 .registry-cache:
 	mkdir -p .registry-cache && chmod -R ag+w .registry-cache

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ test: test-registry test-images
 # Starts a local Docker registry on port 5000 with a local disk cache.
 .PHONY: test-registry
 test-registry: .registry-cache
-	if [ ! curl -fsSL http://localhost:5000/v2/_catalog >/dev/null 2>&1 ]; then \
-		docker rm -f envbuilder-registry; \
+	if ! curl -fsSL http://localhost:5000/v2/_catalog > /dev/null 2>&1; then \
+		docker rm -f envbuilder-registry && \
 		docker run -d -p 5000:5000 --name envbuilder-registry --volume $(PWD)/.registry-cache:/var/lib/registry registry:2; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -224,3 +224,23 @@ docker run -it --rm \
 - [`SSL_CERT_FILE`](https://go.dev/src/crypto/x509/root_unix.go#L19): Specifies the path to an SSL certificate.
 - [`SSL_CERT_DIR`](https://go.dev/src/crypto/x509/root_unix.go#L25): Identifies which directory to check for SSL certificate files.
 - `SSL_CERT_BASE64`: Specifies a base64-encoded SSL certificate that will be added to the global certificate pool on start.
+
+
+# Local Development
+
+Building `envbuilder` currently **requires** a Linux system.
+
+On MacOS or Windows systems, we recommend either using a VM or the provided `.devcontainer` for development.
+
+**Additional Requirements:**
+
+- `go 1.21`
+- `make`
+- Docker daemon (for running tests)
+
+**Makefile targets:**
+
+- `build`: builds and tags `envbuilder:latest` for your current architecture.
+- `develop`: runs `envbuilder:latest` against a sample Git repository.
+- `test`: run tests.
+- `test-registry`: stands up a local registry for caching images used in tests.

--- a/devcontainer/devcontainer_test.go
+++ b/devcontainer/devcontainer_test.go
@@ -78,7 +78,7 @@ func TestCompileWithFeatures(t *testing.T) {
     "context": ".",
   },
   // Comments here!
-  "image": "codercom/code-server:latest",
+  "image": "localhost:5000/envbuilder-test-codercom-code-server:latest",
   "features": {
 	"` + featureOne + `": {},
 	"` + featureTwo + `": "potato"
@@ -96,7 +96,7 @@ func TestCompileWithFeatures(t *testing.T) {
 	featureTwoMD5 := md5.Sum([]byte(featureTwo))
 	featureTwoDir := fmt.Sprintf("/.envbuilder/features/two-%x", featureTwoMD5[:4])
 
-	require.Equal(t, `FROM codercom/code-server:latest
+	require.Equal(t, `FROM localhost:5000/envbuilder-test-codercom-code-server:latest
 
 USER root
 # Rust tomato - Example description!
@@ -116,7 +116,7 @@ func TestCompileDevContainer(t *testing.T) {
 		t.Parallel()
 		fs := memfs.New()
 		dc := &devcontainer.Spec{
-			Image: "codercom/code-server:latest",
+			Image: "localhost:5000/envbuilder-test-ubuntu:latest",
 		}
 		params, err := dc.Compile(fs, "", magicDir, "", "", false)
 		require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestCompileDevContainer(t *testing.T) {
 		require.NoError(t, err)
 		file, err := fs.OpenFile(filepath.Join(dcDir, "Dockerfile"), os.O_CREATE|os.O_WRONLY, 0644)
 		require.NoError(t, err)
-		_, err = io.WriteString(file, "FROM ubuntu")
+		_, err = io.WriteString(file, "FROM localhost:5000/envbuilder-test-ubuntu:latest")
 		require.NoError(t, err)
 		_ = file.Close()
 		params, err := dc.Compile(fs, dcDir, magicDir, "", "/var/workspace", false)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -144,7 +144,7 @@ func TestBuildFromDevcontainerWithFeatures(t *testing.T) {
 					}
 				}
 			}`,
-			".devcontainer/Dockerfile":                         "FROM ubuntu",
+			".devcontainer/Dockerfile":                         "FROM " + testImageUbuntu,
 			".devcontainer/feature3/devcontainer-feature.json": string(feature3Spec),
 			".devcontainer/feature3/install.sh":                "echo $GRAPE > /test3output",
 		},
@@ -262,7 +262,7 @@ func TestBuildFromDevcontainerInCustomPath(t *testing.T) {
 					"dockerfile": "Dockerfile"
 				},
 			}`,
-			".devcontainer/custom/Dockerfile": "FROM ubuntu",
+			".devcontainer/custom/Dockerfile": "FROM " + testImageUbuntu,
 		},
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{
@@ -287,7 +287,7 @@ func TestBuildFromDevcontainerInSubfolder(t *testing.T) {
 					"dockerfile": "Dockerfile"
 				},
 			}`,
-			".devcontainer/subfolder/Dockerfile": "FROM ubuntu",
+			".devcontainer/subfolder/Dockerfile": "FROM " + testImageUbuntu,
 		},
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{
@@ -310,7 +310,7 @@ func TestBuildFromDevcontainerInRoot(t *testing.T) {
 					"dockerfile": "Dockerfile"
 				},
 			}`,
-			"Dockerfile": "FROM ubuntu",
+			"Dockerfile": "FROM " + testImageUbuntu,
 		},
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{
@@ -409,7 +409,7 @@ func TestBuildFailsFallback(t *testing.T) {
 		// Ensures that a Git repository with a Dockerfile is cloned and built.
 		url := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				"Dockerfile": `FROM alpine
+				"Dockerfile": `FROM ` + testImageAlpine + `
 RUN exit 1`,
 			},
 		})
@@ -525,7 +525,7 @@ func TestLifecycleScripts(t *testing.T) {
 					"parallel2": ["sh", "-c", "echo parallel2 > /tmp/parallel2"]
 				}
 			}`,
-			".devcontainer/Dockerfile": "FROM alpine:latest\nUSER nobody",
+			".devcontainer/Dockerfile": "FROM " + testImageAlpine + "\nUSER nobody",
 		},
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{
@@ -561,7 +561,7 @@ func TestPostStartScript(t *testing.T) {
 			".devcontainer/init.sh": `#!/bin/sh
 			/tmp/post-start.sh
 			sleep infinity`,
-			".devcontainer/Dockerfile": `FROM alpine:latest
+			".devcontainer/Dockerfile": `FROM ` + testImageAlpine + `
 COPY init.sh /bin
 RUN chmod +x /bin/init.sh
 USER nobody`,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -588,7 +588,9 @@ func TestPrivateRegistry(t *testing.T) {
 	t.Parallel()
 	t.Run("NoAuth", func(t *testing.T) {
 		t.Parallel()
-		image := setupPassthroughRegistry(t, "thisimagedoesnotexist", &registryAuth{
+		// Even if something goes wrong with auth,
+		// the pull will fail as "scratch" is a reserved name.
+		image := setupPassthroughRegistry(t, "scratch", &registryAuth{
 			Username: "user",
 			Password: "test",
 		})
@@ -637,7 +639,9 @@ func TestPrivateRegistry(t *testing.T) {
 	})
 	t.Run("InvalidAuth", func(t *testing.T) {
 		t.Parallel()
-		image := setupPassthroughRegistry(t, "thisimagedoesnotexist", &registryAuth{
+		// Even if something goes wrong with auth,
+		// the pull will fail as "scratch" is a reserved name.
+		image := setupPassthroughRegistry(t, "scratch", &registryAuth{
 			Username: "user",
 			Password: "banana",
 		})


### PR DESCRIPTION
- Adds a `Makefile`
- Adds a local registry cache to avoid hitting Docker Hub rate-limits
- Updates existing tests to reference locally cached images

Note: there is an existing in-memory registry implementation that I looked into using instead, but this was cheaper to implement.