### PR TITLE
fix: do not inject GIT_USERNAME and GIT_PASSWORD into git clone URL

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -361,12 +361,12 @@ func Run(ctx context.Context, options Options) error {
 		}
 
 		if options.GitUsername != "" || options.GitPassword != "" {
-			gitURL, err := url.Parse(options.GitURL)
-			if err != nil {
-				return fmt.Errorf("parse git url: %w", err)
-			}
-			gitURL.User = url.UserPassword(options.GitUsername, options.GitPassword)
-			options.GitURL = gitURL.String()
+			// Previously, we had been placing credentials in the URL
+			// as well as setting githttp.BasicAuth.
+			// This was removed as it would leak the credentials used
+			// to clone the repo into the resulting workspace.
+			// Users may still hard-code credentials directly into the
+			// git URL themselves, if required.
 
 			cloneOpts.RepoAuth = &githttp.BasicAuth{
 				Username: options.GitUsername,

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -361,13 +361,8 @@ func Run(ctx context.Context, options Options) error {
 		}
 
 		if options.GitUsername != "" || options.GitPassword != "" {
-			// Previously, we had been placing credentials in the URL
-			// as well as setting githttp.BasicAuth.
-			// This was removed as it would leak the credentials used
-			// to clone the repo into the resulting workspace.
-			// Users may still hard-code credentials directly into the
-			// git URL themselves, if required.
-
+			// NOTE: we previously inserted the credentials into the repo URL.
+			// This was removed in https://github.com/coder/envbuilder/pull/141
 			cloneOpts.RepoAuth = &githttp.BasicAuth{
 				Username: options.GitUsername,
 				Password: options.GitPassword,

--- a/gittest/gittest.go
+++ b/gittest/gittest.go
@@ -122,7 +122,7 @@ func WriteFile(t *testing.T, fs billy.Filesystem, path, content string) {
 func BasicAuthMW(username, password string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if username != "" && password != "" {
+			if username != "" || password != "" {
 				authUser, authPass, ok := r.BasicAuth()
 				if !ok || username != authUser || password != authPass {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/gittest/gittest.go
+++ b/gittest/gittest.go
@@ -118,3 +118,18 @@ func WriteFile(t *testing.T, fs billy.Filesystem, path, content string) {
 	err = file.Close()
 	require.NoError(t, err)
 }
+
+func BasicAuthMW(username, password string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if username != "" && password != "" {
+				authUser, authPass, ok := r.BasicAuth()
+				if !ok || username != authUser || password != authPass {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -756,25 +756,10 @@ type gitServerOptions struct {
 func createGitServer(t *testing.T, opts gitServerOptions) string {
 	t.Helper()
 	if opts.authMW == nil {
-		opts.authMW = checkBasicAuth(opts.username, opts.password)
+		opts.authMW = gittest.BasicAuthMW(opts.username, opts.password)
 	}
 	srv := httptest.NewServer(opts.authMW(createGitHandler(t, opts)))
 	return srv.URL
-}
-
-func checkBasicAuth(username, password string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if username != "" && password != "" {
-				authUser, authPass, ok := r.BasicAuth()
-				if !ok || username != authUser || password != authPass {
-					w.WriteHeader(http.StatusUnauthorized)
-					return
-				}
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
 }
 
 func createGitHandler(t *testing.T, opts gitServerOptions) http.Handler {


### PR DESCRIPTION
Fixes https://github.com/coder/envbuilder/issues/126

We had been writing the `GIT_USERNAME` and `GIT_PASSWORD` into the git auth URL as well as setting basic HTTP auth credentials.
This causes `GIT_USERNAME` and `GIT_PASSWORD` to be present in the `.git/config` of the clond repo, which is not desirable. 
This PR removes that behaviour and modifies existing unit tests to assert that the git clone URL is not modified from what the user passes in.

The previous behaviour can be preserved by explicitly setting basic auth in the git clone URL, if required.