### PR TITLE
feat!: add safety check if not running as PID 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ $ vim .devcontainer/Dockerfile
 
 Exit the container, and re-run the `docker run` command... after the build completes, `htop` should exist in the container! 🥳
 
+> **Note:** Envbuilder performs destructive filesystem operations! To guard against accidental data loss, it 
+> will refuse to run if it detects it is not running as PID 1.
+> If you need to bypass this behaviour for any reason, you can bypass this safety check by setting
+> `DANGEROUS_BYPASS_PID_CHECK=1`.
+
 ## Container Registry Authentication
 
 envbuilder uses Kaniko to build containers. You should [follow their instructions](https://github.com/GoogleContainerTools/kaniko#pushing-to-different-registries) to create an authentication configuration.

--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -33,12 +33,12 @@ func main() {
 			options := envbuilder.OptionsFromEnv(os.LookupEnv)
 			if os.Getpid() != 1 {
 				// TODO: rebase once https://github.com/coder/envbuilder/pull/140 is in
-				if env, found := os.LookupEnv("DANGEROUS_BYPASS_PID_CHECK"); found && env == "1" {
-					_, _ = fmt.Fprintln(os.Stderr, `Bypassing PID check as DANGEROUS_BYPASS_PID_CHECK=1.`)
+				if env, found := os.LookupEnv("DANGEROUS_DISABLE_PID_CHECK"); found && env == "1" {
+					_, _ = fmt.Fprintln(os.Stderr, `Bypassing PID check as DANGEROUS_DISABLE_PID_CHECK=1.`)
 				} else {
 					_, _ = fmt.Fprintln(os.Stderr, `WARNING: Not running as PID 1, so exiting IMMEDIATELY!`)
 					_, _ = fmt.Fprintln(os.Stderr, `This is a safety check to guard against accidental data loss when run outside of a container.`)
-					_, _ = fmt.Fprintln(os.Stderr, `To bypass this check, set DANGEROUS_BYPASS_PID_CHECK=1.`)
+					_, _ = fmt.Fprintln(os.Stderr, `To bypass this check, set DANGEROUS_DISABLE_PID_CHECK=1.`)
 					os.Exit(1)
 				}
 			}

--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -31,6 +31,17 @@ func main() {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := envbuilder.OptionsFromEnv(os.LookupEnv)
+			if os.Getpid() != 1 {
+				// TODO: rebase once https://github.com/coder/envbuilder/pull/140 is in
+				if env, found := os.LookupEnv("DANGEROUS_BYPASS_PID_CHECK"); found && env == "1" {
+					_, _ = fmt.Fprintln(os.Stderr, `Bypassing PID check as DANGEROUS_BYPASS_PID_CHECK=1.`)
+				} else {
+					_, _ = fmt.Fprintln(os.Stderr, `WARNING: Not running as PID 1, so exiting IMMEDIATELY!`)
+					_, _ = fmt.Fprintln(os.Stderr, `This is a safety check to guard against accidental data loss when run outside of a container.`)
+					_, _ = fmt.Fprintln(os.Stderr, `To bypass this check, set DANGEROUS_BYPASS_PID_CHECK=1.`)
+					os.Exit(1)
+				}
+			}
 
 			var sendLogs func(ctx context.Context, log ...agentsdk.Log) error
 			agentURL := os.Getenv("CODER_AGENT_URL")


### PR DESCRIPTION
Relates to https://github.com/coder/envbuilder/issues/144
This PR adds a safety check to guard against users accidentally running envbuilder on their local system.
It can be bypassed by setting an environment variable.
This is a breaking change for use-cases outside of containers.