### PR TITLE
test: add test for options env

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -12,15 +12,14 @@ import (
 // TestEnvOptionParsing tests that given environment variables of different types are handled as expected.
 func TestTestEnvOptionParsing(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
-		t.Setenv("SETUP_SCRIPT", "setup.sh")
-		t.Setenv("INIT_COMMAND", "sleep infinity")
+	        const val = "setup.sh"
+		t.Setenv("SETUP_SCRIPT", val)
 
 		var o envbuilder.Options
 		err := runCLI(&o)
 		require.NoError(t, err)
 
-		require.Equal(t, o.SetupScript, "setup.sh")
-		require.Equal(t, o.InitCommand, "sleep infinity")
+		require.Equal(t, o.SetupScript, val)
 	})
 
 	t.Run("int", func(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -10,68 +10,77 @@ import (
 )
 
 // TestEnvOptionParsing tests that given environment variables of different types are handled as expected.
-func TestTestEnvOptionParsing(t *testing.T) {
+func TestEnvOptionParsing(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
-	        const val = "setup.sh"
+		const val = "setup.sh"
 		t.Setenv("SETUP_SCRIPT", val)
-
-		var o envbuilder.Options
-		err := runCLI(&o)
-		require.NoError(t, err)
-
+		o := runCLI()
 		require.Equal(t, o.SetupScript, val)
 	})
 
 	t.Run("int", func(t *testing.T) {
 		t.Setenv("CACHE_TTL_DAYS", "7")
-
-		var o envbuilder.Options
-		err := runCLI(&o)
-		require.NoError(t, err)
-
+		o := runCLI()
 		require.Equal(t, o.CacheTTLDays, int64(7))
 	})
 
 	t.Run("string array", func(t *testing.T) {
 		t.Setenv("IGNORE_PATHS", "/var,/temp")
-
-		var o envbuilder.Options
-		err := runCLI(&o)
-		require.NoError(t, err)
-
+		o := runCLI()
 		require.Equal(t, o.IgnorePaths, []string{"/var", "/temp"})
 	})
 
 	t.Run("bool", func(t *testing.T) {
-		t.Setenv("SKIP_REBUILD", "true")
-		t.Setenv("GIT_CLONE_SINGLE_BRANCH", "false")
-		t.Setenv("EXIT_ON_BUILD_FAILURE", "true")
-		t.Setenv("FORCE_SAFE", "false")
-		t.Setenv("INSECURE", "true")
+		t.Run("lowercase", func(t *testing.T) {
+			t.Setenv("SKIP_REBUILD", "true")
+			t.Setenv("GIT_CLONE_SINGLE_BRANCH", "false")
+			o := runCLI()
+			require.True(t, o.SkipRebuild)
+			require.False(t, o.GitCloneSingleBranch)
+		})
 
-		var o envbuilder.Options
-		err := runCLI(&o)
-		require.NoError(t, err)
+		t.Run("uppercase", func(t *testing.T) {
+			t.Setenv("SKIP_REBUILD", "TRUE")
+			t.Setenv("GIT_CLONE_SINGLE_BRANCH", "FALSE")
+			o := runCLI()
+			require.True(t, o.SkipRebuild)
+			require.False(t, o.GitCloneSingleBranch)
+		})
 
-		require.True(t, o.SkipRebuild)
-		require.False(t, o.GitCloneSingleBranch)
-		require.True(t, o.ExitOnBuildFailure)
-		require.False(t, o.ForceSafe)
-		require.True(t, o.Insecure)
+		t.Run("numeric", func(t *testing.T) {
+			t.Setenv("SKIP_REBUILD", "1")
+			t.Setenv("GIT_CLONE_SINGLE_BRANCH", "0")
+			o := runCLI()
+			require.True(t, o.SkipRebuild)
+			require.False(t, o.GitCloneSingleBranch)
+		})
+
+		t.Run("empty", func(t *testing.T) {
+			t.Setenv("GIT_CLONE_SINGLE_BRANCH", "")
+			o := runCLI()
+			require.False(t, o.GitCloneSingleBranch)
+		})
 	})
 }
 
-func runCLI(o *envbuilder.Options) error {
+func runCLI() envbuilder.Options {
+	var o envbuilder.Options
 	cmd := serpent.Command{
 		Options: o.CLI(),
 		Handler: func(inv *serpent.Invocation) error {
 			return nil
 		},
 	}
+
 	i := cmd.Invoke().WithOS()
 	fakeIO(i)
 	err := i.Run()
-	return err
+
+	if err != nil {
+		panic("failed to run CLI: " + err.Error())
+	}
+
+	return o
 }
 
 type ioBufs struct {

--- a/options_test.go
+++ b/options_test.go
@@ -15,14 +15,15 @@ type testEnvCase struct {
 	Actual   func() interface{}
 }
 
-func TestEnvOptions(t *testing.T) {
+// TestEnvOptionParsing tests that given environment variables of different types are handled as expected.
+func TestEnvOptionParsing(t *testing.T) {
 	t.Setenv("SETUP_SCRIPT", "setup.sh")
 	t.Setenv("CACHE_TTL_DAYS", "7")
 	t.Setenv("IGNORE_PATHS", "/var,/tmp")
 	t.Setenv("SKIP_REBUILD", "true")
 	t.Setenv("GIT_CLONE_SINGLE_BRANCH", "")
 
-	var o = envbuilder.Options{}
+	var o envbuilder.Options
 	cmd := serpent.Command{
 		Options: o.CLI(),
 		Handler: func(inv *serpent.Invocation) error {

--- a/options_test.go
+++ b/options_test.go
@@ -8,13 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testEnvCase struct {
-	Env      string
-	EnvValue string
-	Expected interface{}
-	Actual   func() interface{}
-}
-
 // TestEnvOptionParsing tests that given environment variables of different types are handled as expected.
 func TestEnvOptionParsing(t *testing.T) {
 	t.Setenv("SETUP_SCRIPT", "setup.sh")

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,40 @@
+package envbuilder_test
+
+import (
+	"testing"
+
+	"github.com/coder/envbuilder"
+	"github.com/coder/serpent"
+	"github.com/stretchr/testify/require"
+)
+
+type testEnvCase struct {
+	Env      string
+	EnvValue string
+	Expected interface{}
+	Actual   func() interface{}
+}
+
+func TestEnvOptions(t *testing.T) {
+	t.Setenv("SETUP_SCRIPT", "setup.sh")
+	t.Setenv("CACHE_TTL_DAYS", "7")
+	t.Setenv("IGNORE_PATHS", "/var,/tmp")
+	t.Setenv("SKIP_REBUILD", "true")
+	t.Setenv("GIT_CLONE_SINGLE_BRANCH", "")
+
+	var o = envbuilder.Options{}
+	cmd := serpent.Command{
+		Options: o.CLI(),
+		Handler: func(inv *serpent.Invocation) error {
+			return nil
+		},
+	}
+	err := cmd.Invoke().WithOS().Run()
+	require.NoError(t, err)
+
+	require.Equal(t, o.SetupScript, "setup.sh")
+	require.Equal(t, o.CacheTTLDays, int64(7))
+	require.Equal(t, o.IgnorePaths, []string{"/var", "/tmp"})
+	require.True(t, o.SkipRebuild)
+	require.False(t, o.GitCloneSingleBranch)
+}

--- a/options_test.go
+++ b/options_test.go
@@ -8,15 +8,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEnvOptionParsing tests that given environment variables of different types are handled as expected.
-func TestEnvOptionParsing(t *testing.T) {
+// TestStrEnvOptions tests that string env variables can be handled as expected.
+func TestStrEnvOptions(t *testing.T) {
 	t.Setenv("SETUP_SCRIPT", "setup.sh")
-	t.Setenv("CACHE_TTL_DAYS", "7")
-	t.Setenv("IGNORE_PATHS", "/var,/tmp")
-	t.Setenv("SKIP_REBUILD", "true")
-	t.Setenv("GIT_CLONE_SINGLE_BRANCH", "")
+	t.Setenv("INIT_COMMAND", "sleep infinity")
 
 	var o envbuilder.Options
+	err := runCLI(&o)
+	require.NoError(t, err)
+
+	require.Equal(t, o.SetupScript, "setup.sh")
+	require.Equal(t, o.InitCommand, "sleep infinity")
+}
+
+// TestIntEnvOptions tests that numeric env variables can be handled as expected.
+func TestIntEnvOptions(t *testing.T) {
+	t.Setenv("CACHE_TTL_DAYS", "7")
+
+	var o envbuilder.Options
+	err := runCLI(&o)
+	require.NoError(t, err)
+
+	require.Equal(t, o.CacheTTLDays, 7)
+}
+
+// TestMultipleStrEnvOptions tests that numeric env variables can be handled as expected.
+func TestMultipleStrEnvOptions(t *testing.T) {
+	t.Setenv("CACHE_TTL_DAYS", "7")
+
+	var o envbuilder.Options
+	err := runCLI(&o)
+	require.NoError(t, err)
+
+	require.Equal(t, o.CacheTTLDays, 7)
+}
+
+// TestBoolEnvOptions tests that boolean env variables can be handled as expected.
+func TestBoolEnvOptions(t *testing.T) {
+	t.Setenv("SKIP_REBUILD", "true")
+	t.Setenv("GIT_CLONE_SINGLE_BRANCH", "")
+	t.Setenv("EXIT_ON_BUILD_FAILURE", "false")
+	t.Setenv("FORCE_SAFE", "TRUE")
+	t.Setenv("INSECURE", "FALSE")
+
+	var o envbuilder.Options
+	err := runCLI(&o)
+	require.NoError(t, err)
+
+	require.True(t, o.SkipRebuild)
+	require.False(t, o.GitCloneSingleBranch)
+	require.False(t, o.ExitOnBuildFailure)
+	require.True(t, o.ForceSafe)
+	require.False(t, o.Insecure)
+}
+
+func runCLI(o *envbuilder.Options) error {
 	cmd := serpent.Command{
 		Options: o.CLI(),
 		Handler: func(inv *serpent.Invocation) error {
@@ -24,11 +70,5 @@ func TestEnvOptionParsing(t *testing.T) {
 		},
 	}
 	err := cmd.Invoke().WithOS().Run()
-	require.NoError(t, err)
-
-	require.Equal(t, o.SetupScript, "setup.sh")
-	require.Equal(t, o.CacheTTLDays, int64(7))
-	require.Equal(t, o.IgnorePaths, []string{"/var", "/tmp"})
-	require.True(t, o.SkipRebuild)
-	require.False(t, o.GitCloneSingleBranch)
+	return err
 }


### PR DESCRIPTION
After some thinking, I concluded that we don't need to test all the env vars but how those values are parsed, but let me know if you think we should test all the env variables.

Closes https://github.com/coder/envbuilder/issues/157