### PR TITLE
feat: support cloning over SSH via private key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,7 @@ On MacOS or Windows systems, we recommend either using a VM or the provided `.de
 | `--git-clone-single-branch` | `GIT_CLONE_SINGLE_BRANCH` |  | Clone only a single branch of the Git repository. |
 | `--git-username` | `GIT_USERNAME` |  | The username to use for Git authentication. This is optional. |
 | `--git-password` | `GIT_PASSWORD` |  | The password to use for Git authentication. This is optional. |
-| `--git-ssh-private-key-path` | `GIT_SSH_PRIVATE_KEY_PATH` |  | Path to a SSH private key to be used for Git authentication. |
-| `--git-ssh-known-hosts-base64` | `GIT_SSH_KNOWN_HOSTS_BASE64` |  | Base64-encoded content of a known hosts file. If not specified, host keys will be scanned and logged, but not checked. |
+| `--git-ssh-private-key-path` | `GIT_SSH_PRIVATE_KEY_PATH` |  | Path to an SSH private key to be used for Git authentication. |
 | `--git-http-proxy-url` | `GIT_HTTP_PROXY_URL` |  | The URL for the HTTP proxy. This is optional. |
 | `--workspace-folder` | `WORKSPACE_FOLDER` |  | The path to the workspace folder that will be built. This is optional. |
 | `--ssl-cert-base64` | `SSL_CERT_BASE64` |  | The content of an SSL cert file. This is useful for self-signed certificates. |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,12 @@ DOCKER_CONFIG_BASE64=ewoJImF1dGhzIjogewoJCSJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8
 
 ## Git Authentication
 
-`GIT_USERNAME` and `GIT_PASSWORD` are environment variables to provide Git authentication for private repositories.
+Two methods of authentication are supported:
+
+### HTTP Authentication
+
+If the `GIT_URL` supplied starts with `http://` or `https://`, envbuilder will
+supply HTTP basic authentication using `GIT_USERNAME` and `GIT_PASSWORD`, if set.
 
 For access token-based authentication, follow the following schema (if empty, there's no need to provide the field):
 
@@ -160,6 +165,42 @@ resource "docker_container" "dev" {
     ]
 }
 ```
+
+### SSH Authentication
+
+If the `GIT_URL` supplied does not start with `http://` or `https://`,
+envbuilder will assume SSH authentication. You have the following options:
+
+1. Public/Private key authentication: set `GIT_SSH_KEY_PATH` to the path of an
+   SSH private key mounted inside the container. Envbuilder will use this SSH
+   key to authenticate. Example:
+
+   ```bash
+    docker run -it --rm \
+      -v /tmp/envbuilder:/workspaces \
+      -e GIT_URL=git@example.com:path/to/private/repo.git \
+      -e GIT_SSH_KEY_PATH=/.ssh/id_rsa \
+      -v /home/user/id_rsa:/.ssh/id_rsa \
+      -e INIT_SCRIPT=bash \
+      ghcr.io/coder/envbuilder
+   ```
+
+1. Agent-based authentication: set `SSH_AUTH_SOCK` and mount in your agent socket, for example:
+
+  ```bash
+    docker run -it --rm \
+      -v /tmp/envbuilder:/workspaces \
+      -e GIT_URL=git@example.com:path/to/private/repo.git \
+      -e INIT_SCRIPT=bash \
+      -e SSH_AUTH_SOCK=/tmp/ssh-auth-sock \
+      -v $SSH_AUTH_SOCK:/tmp/ssh-auth-sock \
+      ghcr.io/coder/envbuilder
+  ```
+
+> Note: by default, envbuilder will accept and log all host keys. If you need
+> strict host key checking, set `SSH_KNOWN_HOSTS` and mount in a `known_hosts`
+> file.
+
 
 ## Layer Caching
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ On MacOS or Windows systems, we recommend either using a VM or the provided `.de
 | `--git-clone-single-branch` | `GIT_CLONE_SINGLE_BRANCH` |  | Clone only a single branch of the Git repository. |
 | `--git-username` | `GIT_USERNAME` |  | The username to use for Git authentication. This is optional. |
 | `--git-password` | `GIT_PASSWORD` |  | The password to use for Git authentication. This is optional. |
+| `--git-ssh-private-key-path` | `GIT_SSH_PRIVATE_KEY_PATH` |  | Path to a SSH private key to be used for Git authentication. |
+| `--git-ssh-known-hosts-base64` | `GIT_SSH_KNOWN_HOSTS_BASE64` |  | Base64-encoded content of a known hosts file. If not specified, host keys will be scanned and logged, but not checked. |
 | `--git-http-proxy-url` | `GIT_HTTP_PROXY_URL` |  | The URL for the HTTP proxy. This is optional. |
 | `--workspace-folder` | `WORKSPACE_FOLDER` |  | The path to the workspace folder that will be built. This is optional. |
 | `--ssl-cert-base64` | `SSL_CERT_BASE64` |  | The content of an SSL cert file. This is useful for self-signed certificates. |

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -44,8 +44,6 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sirupsen/logrus"
@@ -157,36 +155,6 @@ func Run(ctx context.Context, options Options) error {
 		}
 	}
 
-	if options.GitURL != "" {
-		gitURLParsed, err := ParseGitURL(options.GitURL)
-		if err != nil {
-			return fmt.Errorf("invalid git URL: %w", err)
-		}
-		// If we're cloning over SSH, we need a known_hosts file.
-		if gitURLParsed.Scheme == "ssh" {
-			var knownHostsContent []byte
-			if options.GitSSHKnownHostsBase64 != "" {
-				if kh, err := base64.StdEncoding.DecodeString(options.GitSSHKnownHostsBase64); err != nil {
-					return fmt.Errorf("invalid known_hosts content: %w", err)
-				} else {
-					knownHostsContent = kh
-				}
-			} else {
-				// This is a best-effort.
-				kh, err := KeyScan(options.Logger, gitURLParsed)
-				if err == nil {
-					knownHostsContent = kh
-				}
-			}
-			knownHostsPath := filepath.Join(MagicDir, "known_hosts")
-			if err := os.WriteFile(knownHostsPath, knownHostsContent, 0644); err != nil {
-				return fmt.Errorf("write known_hosts file: %w", err)
-			}
-			// go-git will read this file to validate the server host keys.
-			_ = os.Setenv("SSH_KNOWN_HOSTS", knownHostsPath)
-		}
-	}
-
 	var fallbackErr error
 	var cloned bool
 	if options.GitURL != "" {
@@ -225,23 +193,7 @@ func Run(ctx context.Context, options Options) error {
 			CABundle:     caBundle,
 		}
 
-		if options.GitUsername != "" || options.GitPassword != "" {
-			// NOTE: we previously inserted the credentials into the repo URL.
-			// This was removed in https://github.com/coder/envbuilder/pull/141
-			cloneOpts.RepoAuth = &githttp.BasicAuth{
-				Username: options.GitUsername,
-				Password: options.GitPassword,
-			}
-		} else if options.GitSSHPrivateKeyPath != "" {
-			signer, err := ReadPrivateKey(options.GitSSHPrivateKeyPath)
-			if err != nil {
-				return xerrors.Errorf("read private key: %w", err)
-			}
-			cloneOpts.RepoAuth = &gitssh.PublicKeys{
-				User:   "git",
-				Signer: signer,
-			}
-		}
+		cloneOpts.RepoAuth = SetupRepoAuth(&options)
 		if options.GitHTTPProxyURL != "" {
 			cloneOpts.ProxyOptions = transport.ProxyOptions{
 				URL: options.GitHTTPProxyURL,

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -171,7 +171,7 @@ func Run(ctx context.Context, options Options) error {
 				knownHostsContent = kh
 			}
 		} else {
-			kh, err := GenerateKnownHosts(options.Logger, gitURLParsed)
+			kh, err := KeyScan(options.Logger, gitURLParsed)
 			if err != nil {
 				return fmt.Errorf("invalid known_hosts content: %w", err)
 			} else {

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -157,7 +157,7 @@ func Run(ctx context.Context, options Options) error {
 		}
 	}
 
-	gitURLParsed, err := url.Parse(options.GitURL)
+	gitURLParsed, err := ParseGitURL(options.GitURL)
 	if err != nil {
 		return fmt.Errorf("invalid git URL: %w", err)
 	}
@@ -182,6 +182,7 @@ func Run(ctx context.Context, options Options) error {
 		if err := os.WriteFile(knownHostsPath, knownHostsContent, 0644); err != nil {
 			return fmt.Errorf("write known_hosts file: %w", err)
 		}
+		// go-git will read this file to validate the server host keys.
 		_ = os.Setenv("SSH_KNOWN_HOSTS", knownHostsPath)
 	}
 

--- a/git.go
+++ b/git.go
@@ -123,6 +123,8 @@ func CloneRepo(ctx context.Context, opts CloneRepoOptions) (bool, error) {
 	return true, nil
 }
 
+// ReadPrivateKey attempts to read an SSH private key from path
+// and returns an ssh.Signer.
 func ReadPrivateKey(path string) (gossh.Signer, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -131,11 +131,11 @@ func ReadPrivateKey(path string) (gossh.Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open private key file: %w", err)
 	}
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, f); err != nil {
+	bs, err := io.ReadAll(f)
+	if err != nil {
 		return nil, fmt.Errorf("read private key file: %w", err)
 	}
-	k, err := gossh.ParsePrivateKey(buf.Bytes())
+	k, err := gossh.ParsePrivateKey(bs)
 	if err != nil {
 		return nil, fmt.Errorf("parse private key file: %w", err)
 	}

--- a/git.go
+++ b/git.go
@@ -195,8 +195,8 @@ func KnownHostsLine(dialAddr string, key gossh.PublicKey) (string, error) {
 
 func hostPort(u *url.URL) string {
 	p := 22 // assume default SSH port
-	if _p, err := strconv.Atoi(u.Port()); err == nil {
-		p = _p
+	if tmp, err := strconv.Atoi(u.Port()); err == nil {
+		p = tmp
 	}
 	return fmt.Sprintf("%s:%d", u.Host, p)
 }

--- a/git.go
+++ b/git.go
@@ -131,6 +131,7 @@ func ReadPrivateKey(path string) (gossh.Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open private key file: %w", err)
 	}
+	defer f.Close()
 	bs, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("read private key file: %w", err)
@@ -199,9 +200,8 @@ func SetupRepoAuth(options *Options) transport.AuthMethod {
 
 	// Generally git clones over SSH use the 'git' user, but respect
 	// GIT_USERNAME if set.
-	authUser := options.GitUsername
-	if authUser == "" {
-		authUser = "git"
+	if options.GitUsername == "" {
+		options.GitUsername = "git"
 	}
 
 	// Assume SSH auth for all other formats.
@@ -221,7 +221,7 @@ func SetupRepoAuth(options *Options) transport.AuthMethod {
 	// If no SSH key set, fall back to agent auth.
 	if signer == nil {
 		options.Logger(codersdk.LogLevelError, "#1: 🔑 No SSH key found, falling back to agent!")
-		auth, err := gitssh.NewSSHAgentAuth(authUser)
+		auth, err := gitssh.NewSSHAgentAuth(options.GitUsername)
 		if err != nil {
 			options.Logger(codersdk.LogLevelError, "#1: ❌ Failed to connect to SSH agent: %s", err.Error())
 			return nil // nothing else we can do

--- a/git.go
+++ b/git.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -198,4 +199,16 @@ func hostPort(u *url.URL) string {
 		p = _p
 	}
 	return fmt.Sprintf("%s:%d", u.Host, p)
+}
+
+var schemaRe = regexp.MustCompile(`^[a-zA-Z]+://`)
+
+// ParseGitURL will normalize a git URL without a leading schema.
+// If no schema is provided, we will default to ssh://.
+func ParseGitURL(gitURL string) (*url.URL, error) {
+	if !schemaRe.MatchString(gitURL) {
+		gitURL = "ssh://" + gitURL
+
+	}
+	return url.Parse(gitURL)
 }

--- a/git_test.go
+++ b/git_test.go
@@ -320,9 +320,8 @@ func TestSetupRepoAuth(t *testing.T) {
 			Logger: testLog(t),
 		}
 		auth := envbuilder.SetupRepoAuth(opts)
-		pk, ok := auth.(*gitssh.PublicKeys)
+		_, ok := auth.(*gitssh.PublicKeysCallback)
 		require.True(t, ok)
-		require.Equal(t, "git", pk.User)
 	})
 
 	t.Run("SSH/NoScheme", func(t *testing.T) {
@@ -332,9 +331,8 @@ func TestSetupRepoAuth(t *testing.T) {
 			Logger: testLog(t),
 		}
 		auth := envbuilder.SetupRepoAuth(opts)
-		pk, ok := auth.(*gitssh.PublicKeys)
+		_, ok := auth.(*gitssh.PublicKeysCallback)
 		require.True(t, ok)
-		require.Equal(t, "git", pk.User)
 	})
 
 	t.Run("SSH/GitUsername", func(t *testing.T) {
@@ -345,9 +343,8 @@ func TestSetupRepoAuth(t *testing.T) {
 			Logger:      testLog(t),
 		}
 		auth := envbuilder.SetupRepoAuth(opts)
-		pk, ok := auth.(*gitssh.PublicKeys)
+		_, ok := auth.(*gitssh.PublicKeysCallback)
 		require.True(t, ok)
-		require.Equal(t, "user", pk.User)
 	})
 
 	t.Run("SSH/PrivateKey", func(t *testing.T) {
@@ -391,9 +388,8 @@ QFBgc=
 			Logger:               testLog(t),
 		}
 		auth := envbuilder.SetupRepoAuth(opts)
-		pk, ok := auth.(*gitssh.PublicKeys)
+		_, ok := auth.(*gitssh.PublicKeysCallback)
 		require.True(t, ok)
-		require.Nil(t, pk.Signer)
 	})
 }
 

--- a/git_test.go
+++ b/git_test.go
@@ -332,6 +332,19 @@ func TestSetupRepoAuth(t *testing.T) {
 		require.True(t, ok)
 	})
 
+	t.Run("SSH/OtherScheme", func(t *testing.T) {
+		// Anything that is not https:// or http:// is treated as SSH.
+		kPath := writeTestPrivateKey(t)
+		opts := &envbuilder.Options{
+			GitURL:               "git://git@host.tld:repo/path",
+			GitSSHPrivateKeyPath: kPath,
+			Logger:               testLog(t),
+		}
+		auth := envbuilder.SetupRepoAuth(opts)
+		_, ok := auth.(*gitssh.PublicKeys)
+		require.True(t, ok)
+	})
+
 	t.Run("SSH/GitUsername", func(t *testing.T) {
 		kPath := writeTestPrivateKey(t)
 		opts := &envbuilder.Options{

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/docker/cli v26.1.0+incompatible
 	github.com/docker/docker v23.0.8+incompatible
 	github.com/fatih/color v1.16.0
+	github.com/gliderlabs/ssh v0.3.7
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/go-containerregistry v0.15.2
@@ -36,6 +37,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
+	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 )
@@ -70,6 +72,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.20.3 // indirect
@@ -261,7 +264,6 @@ require (
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	go4.org/netipx v0.0.0-20230728180743-ad4cb58a6516 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
-	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.23.0 // indirect

--- a/options.go
+++ b/options.go
@@ -247,7 +247,7 @@ func (o *Options) CLI() serpent.OptionSet {
 			Flag:        "git-ssh-private-key-path",
 			Env:         "GIT_SSH_PRIVATE_KEY_PATH",
 			Value:       serpent.StringOf(&o.GitSSHPrivateKeyPath),
-			Description: "Path to a SSH private key to be used for Git authentication.",
+			Description: "Path to an SSH private key to be used for Git authentication.",
 		},
 		{
 			Flag:        "git-http-proxy-url",

--- a/options.go
+++ b/options.go
@@ -13,37 +13,36 @@ type LoggerFunc func(level codersdk.LogLevel, format string, args ...interface{}
 
 // Options contains the configuration for the envbuilder.
 type Options struct {
-	SetupScript            string
-	InitScript             string
-	InitCommand            string
-	InitArgs               string
-	CacheRepo              string
-	BaseImageCacheDir      string
-	LayerCacheDir          string
-	DevcontainerDir        string
-	DevcontainerJSONPath   string
-	DockerfilePath         string
-	BuildContextPath       string
-	CacheTTLDays           int64
-	DockerConfigBase64     string
-	FallbackImage          string
-	ExitOnBuildFailure     bool
-	ForceSafe              bool
-	Insecure               bool
-	IgnorePaths            []string
-	SkipRebuild            bool
-	GitURL                 string
-	GitCloneDepth          int64
-	GitCloneSingleBranch   bool
-	GitUsername            string
-	GitPassword            string
-	GitSSHPrivateKeyPath   string
-	GitSSHKnownHostsBase64 string
-	GitHTTPProxyURL        string
-	WorkspaceFolder        string
-	SSLCertBase64          string
-	ExportEnvFile          string
-	PostStartScriptPath    string
+	SetupScript          string
+	InitScript           string
+	InitCommand          string
+	InitArgs             string
+	CacheRepo            string
+	BaseImageCacheDir    string
+	LayerCacheDir        string
+	DevcontainerDir      string
+	DevcontainerJSONPath string
+	DockerfilePath       string
+	BuildContextPath     string
+	CacheTTLDays         int64
+	DockerConfigBase64   string
+	FallbackImage        string
+	ExitOnBuildFailure   bool
+	ForceSafe            bool
+	Insecure             bool
+	IgnorePaths          []string
+	SkipRebuild          bool
+	GitURL               string
+	GitCloneDepth        int64
+	GitCloneSingleBranch bool
+	GitUsername          string
+	GitPassword          string
+	GitSSHPrivateKeyPath string
+	GitHTTPProxyURL      string
+	WorkspaceFolder      string
+	SSLCertBase64        string
+	ExportEnvFile        string
+	PostStartScriptPath  string
 	// Logger is the logger to use for all operations.
 	Logger LoggerFunc
 	// Filesystem is the filesystem to use for all operations.
@@ -249,13 +248,6 @@ func (o *Options) CLI() serpent.OptionSet {
 			Env:         "GIT_SSH_PRIVATE_KEY_PATH",
 			Value:       serpent.StringOf(&o.GitSSHPrivateKeyPath),
 			Description: "Path to a SSH private key to be used for Git authentication.",
-		},
-		{
-			Flag:  "git-ssh-known-hosts-base64",
-			Env:   "GIT_SSH_KNOWN_HOSTS_BASE64",
-			Value: serpent.StringOf(&o.GitSSHKnownHostsBase64),
-			Description: "Base64-encoded content of a known hosts file. If not specified, " +
-				"host keys will be scanned and logged, but not checked.",
 		},
 		{
 			Flag:        "git-http-proxy-url",

--- a/options.go
+++ b/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	GitCloneSingleBranch bool
 	GitUsername          string
 	GitPassword          string
+	GitSSHPrivateKeyPath string
 	GitHTTPProxyURL      string
 	WorkspaceFolder      string
 	SSLCertBase64        string
@@ -241,6 +242,12 @@ func (o *Options) CLI() serpent.OptionSet {
 			Env:         "GIT_PASSWORD",
 			Value:       serpent.StringOf(&o.GitPassword),
 			Description: "The password to use for Git authentication. This is optional.",
+		},
+		{
+			Flag:        "git-ssh-private-key-path",
+			Env:         "GIT_SSH_PRIVATE_KEY_PATH",
+			Value:       serpent.StringOf(&o.GitSSHPrivateKeyPath),
+			Description: "Path to a SSH private key to be used for Git authentication.",
 		},
 		{
 			Flag:        "git-http-proxy-url",

--- a/options.go
+++ b/options.go
@@ -13,36 +13,37 @@ type LoggerFunc func(level codersdk.LogLevel, format string, args ...interface{}
 
 // Options contains the configuration for the envbuilder.
 type Options struct {
-	SetupScript          string
-	InitScript           string
-	InitCommand          string
-	InitArgs             string
-	CacheRepo            string
-	BaseImageCacheDir    string
-	LayerCacheDir        string
-	DevcontainerDir      string
-	DevcontainerJSONPath string
-	DockerfilePath       string
-	BuildContextPath     string
-	CacheTTLDays         int64
-	DockerConfigBase64   string
-	FallbackImage        string
-	ExitOnBuildFailure   bool
-	ForceSafe            bool
-	Insecure             bool
-	IgnorePaths          []string
-	SkipRebuild          bool
-	GitURL               string
-	GitCloneDepth        int64
-	GitCloneSingleBranch bool
-	GitUsername          string
-	GitPassword          string
-	GitSSHPrivateKeyPath string
-	GitHTTPProxyURL      string
-	WorkspaceFolder      string
-	SSLCertBase64        string
-	ExportEnvFile        string
-	PostStartScriptPath  string
+	SetupScript            string
+	InitScript             string
+	InitCommand            string
+	InitArgs               string
+	CacheRepo              string
+	BaseImageCacheDir      string
+	LayerCacheDir          string
+	DevcontainerDir        string
+	DevcontainerJSONPath   string
+	DockerfilePath         string
+	BuildContextPath       string
+	CacheTTLDays           int64
+	DockerConfigBase64     string
+	FallbackImage          string
+	ExitOnBuildFailure     bool
+	ForceSafe              bool
+	Insecure               bool
+	IgnorePaths            []string
+	SkipRebuild            bool
+	GitURL                 string
+	GitCloneDepth          int64
+	GitCloneSingleBranch   bool
+	GitUsername            string
+	GitPassword            string
+	GitSSHPrivateKeyPath   string
+	GitSSHKnownHostsBase64 string
+	GitHTTPProxyURL        string
+	WorkspaceFolder        string
+	SSLCertBase64          string
+	ExportEnvFile          string
+	PostStartScriptPath    string
 	// Logger is the logger to use for all operations.
 	Logger LoggerFunc
 	// Filesystem is the filesystem to use for all operations.
@@ -248,6 +249,13 @@ func (o *Options) CLI() serpent.OptionSet {
 			Env:         "GIT_SSH_PRIVATE_KEY_PATH",
 			Value:       serpent.StringOf(&o.GitSSHPrivateKeyPath),
 			Description: "Path to a SSH private key to be used for Git authentication.",
+		},
+		{
+			Flag:  "git-ssh-known-hosts-base64",
+			Env:   "GIT_SSH_KNOWN_HOSTS_BASE64",
+			Value: serpent.StringOf(&o.GitSSHKnownHostsBase64),
+			Description: "Base64-encoded content of a known hosts file. If not specified, " +
+				"host keys will be scanned and logged, but not checked.",
 		},
 		{
 			Flag:        "git-http-proxy-url",

--- a/testdata/options.golden
+++ b/testdata/options.golden
@@ -91,7 +91,7 @@ OPTIONS:
           The password to use for Git authentication. This is optional.
 
       --git-ssh-private-key-path string, $GIT_SSH_PRIVATE_KEY_PATH
-          Path to a SSH private key to be used for Git authentication.
+          Path to an SSH private key to be used for Git authentication.
 
       --git-url string, $GIT_URL
           The URL of the Git repository to clone. This is optional.

--- a/testdata/options.golden
+++ b/testdata/options.golden
@@ -90,10 +90,6 @@ OPTIONS:
       --git-password string, $GIT_PASSWORD
           The password to use for Git authentication. This is optional.
 
-      --git-ssh-known-hosts-base64 string, $GIT_SSH_KNOWN_HOSTS_BASE64
-          Base64-encoded content of a known hosts file. If not specified, host
-          keys will be scanned and logged, but not checked.
-
       --git-ssh-private-key-path string, $GIT_SSH_PRIVATE_KEY_PATH
           Path to a SSH private key to be used for Git authentication.
 

--- a/testdata/options.golden
+++ b/testdata/options.golden
@@ -90,6 +90,13 @@ OPTIONS:
       --git-password string, $GIT_PASSWORD
           The password to use for Git authentication. This is optional.
 
+      --git-ssh-known-hosts-base64 string, $GIT_SSH_KNOWN_HOSTS_BASE64
+          Base64-encoded content of a known hosts file. If not specified, host
+          keys will be scanned and logged, but not checked.
+
+      --git-ssh-private-key-path string, $GIT_SSH_PRIVATE_KEY_PATH
+          Path to a SSH private key to be used for Git authentication.
+
       --git-url string, $GIT_URL
           The URL of the Git repository to clone. This is optional.
 

--- a/testutil/gittest/gittest.go
+++ b/testutil/gittest/gittest.go
@@ -1,12 +1,20 @@
 package gittest
 
 import (
+	"fmt"
+	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/gliderlabs/ssh"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -95,6 +103,97 @@ func NewServer(fs billy.Filesystem) http.Handler {
 		}
 	})
 	return mux
+}
+
+func NewServerSSH(t *testing.T, fs billy.Filesystem, pubkeys ...gossh.PublicKey) *transport.Endpoint {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	srvOpts := []ssh.Option{
+		ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+			for _, pk := range pubkeys {
+				if ssh.KeysEqual(pk, key) {
+					return true
+				}
+			}
+			return false
+		}),
+	}
+
+	done := make(chan struct{}, 1)
+	go func() {
+		_ = ssh.Serve(l, handleSession, srvOpts...)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = l.Close()
+		<-done
+	})
+
+	addr, ok := l.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	tr, err := transport.NewEndpoint(fmt.Sprintf("ssh://git@%s:%d/", addr.IP, addr.Port))
+	require.NoError(t, err)
+	return tr
+}
+
+func handleSession(sess ssh.Session) {
+	c := sess.Command()
+	if len(c) < 1 {
+		_, _ = fmt.Fprintf(os.Stderr, "invalid command: %q\n", c)
+	}
+
+	cmd := exec.Command(c[0], c[1:]...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "cmd stdout pipe: %s\n", err.Error())
+		return
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "cmd stdin pipe: %s\n", err.Error())
+		return
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "cmd stderr pipe: %s\n", err.Error())
+		return
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "start cmd: %s\n", err.Error())
+		return
+	}
+
+	go func() {
+		defer stdin.Close()
+		_, _ = io.Copy(stdin, sess)
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(sess.Stderr(), stderr)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(sess, stdout)
+	}()
+
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "wait cmd: %s\n", err.Error())
+	}
 }
 
 // CommitFunc commits to a repo.


### PR DESCRIPTION
Relates to https://github.com/coder/envbuilder/issues/31

Currently running into issues with testing end-to-end flow.
However, I've tested with a private git repo:

```
$ docker run -it --rm -e GIT_URL="ssh://git@github.com/johnstcn/test-private-devcontainer" -e INIT_SCRIPT=bash -e GIT_SSH_PRIVATE_KEY_PATH=/.ssh/id_ed25519 -v /Users/cian/.ssh/id_ed25519:/.ssh/id_ed25519 envbuilder:latest
envbuilder - Build development environments from repositories in a container
ssh keyscan: github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
#1: 📦 Cloning ssh://git@github.com/johnstcn/test-private-devcontainer to /workspaces/test-private-devcontainer...
#1: Enumerating objects: 6, done.
#1: Counting objects:  16% (1/6)
#1: Counting objects:  33% (2/6)
#1: Counting objects:  50% (3/6)
#1: Counting objects:  66% (4/6)
#1: Counting obj
#1: ects:  83% (5/6)
#1: Counting objects: 100% (6/6)
#1: Counting objects: 100% (6/6), done.
#1: Compressing objects:  16% (1/6)
#1: Compressing objects:  33% (2/6)
#1: Compressing objects:  50% (3/6)
#1: Compressing objects:  66% (4/6)
#1: Compressing objects:  83% (5/6)
#1: Compressing objects: 100% (6/6)
#1: Compressing objects: 100% (6/6), done.
#1: Total 6 (delta 0), reused 6 (delta 0), pack-reused 0
#1: 📦 Cloned repository! [1.434724587s]
```

One potential issue for which I don't have a solution is that passing an SSH key in as a volume will result in the file being available in the resulting workspace. This may not be desirable; an alternative would be to pass in the SSH key as a base64-encoded file (similar to known_hosts) and clean it up after the build completes.

After this is merged, I'd like to do a follow-up PR to refactor some of the envbuilder setup code.