### PR TITLE
fix: use serpent.String instead of serpent.URL for CODER_AGENT_URL

### DIFF
--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -31,10 +32,14 @@ func main() {
 		Handler: func(inv *serpent.Invocation) error {
 			var sendLogs func(ctx context.Context, log ...agentsdk.Log) error
 			if options.CoderAgentToken != "" {
-				if options.CoderAgentURL == nil {
+				if options.CoderAgentURL == "" {
 					return errors.New("CODER_AGENT_URL must be set if CODER_AGENT_TOKEN is set")
 				}
-				client := agentsdk.New(options.CoderAgentURL)
+				u, err := url.Parse(options.CoderAgentURL)
+				if err != nil {
+					return fmt.Errorf("invalid value for CODER_AGENT_URL: %w", err)
+				}
+				client := agentsdk.New(u)
 				client.SetSessionToken(options.CoderAgentToken)
 				client.SDK.HTTPClient = &http.Client{
 					Transport: &http.Transport{

--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -37,7 +37,7 @@ func main() {
 				}
 				u, err := url.Parse(options.CoderAgentURL)
 				if err != nil {
-					return fmt.Errorf("invalid value for CODER_AGENT_URL: %w", err)
+					return fmt.Errorf("unable to parse CODER_AGENT_URL as URL: %w", err)
 				}
 				client := agentsdk.New(u)
 				client.SetSessionToken(options.CoderAgentToken)

--- a/options.go
+++ b/options.go
@@ -131,6 +131,7 @@ type Options struct {
 	Filesystem billy.Filesystem
 	// These options are specifically used when envbuilder is invoked as part of a
 	// Coder workspace.
+	// Revert to `*url.URL` once https://github.com/coder/serpent/issues/14 is fixed.
 	CoderAgentURL string
 	// CoderAgentToken is the authentication token for a Coder agent.
 	CoderAgentToken string

--- a/options.go
+++ b/options.go
@@ -1,7 +1,6 @@
 package envbuilder
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/coder/coder/v2/codersdk"
@@ -132,7 +131,7 @@ type Options struct {
 	Filesystem billy.Filesystem
 	// These options are specifically used when envbuilder is invoked as part of a
 	// Coder workspace.
-	CoderAgentURL *url.URL
+	CoderAgentURL string
 	// CoderAgentToken is the authentication token for a Coder agent.
 	CoderAgentToken string
 	// CoderAgentSubsystem is the Coder agent subsystems to report when forwarding
@@ -375,7 +374,7 @@ func (o *Options) CLI() serpent.OptionSet {
 		{
 			Flag:  "coder-agent-url",
 			Env:   "CODER_AGENT_URL",
-			Value: serpent.URLOf(o.CoderAgentURL),
+			Value: serpent.StringOf(&o.CoderAgentURL),
 			Description: "URL of the Coder deployment. If CODER_AGENT_TOKEN is also " +
 				"set, logs from envbuilder will be forwarded here and will be " +
 				"visible in the workspace build logs.",

--- a/testdata/options.golden
+++ b/testdata/options.golden
@@ -28,7 +28,7 @@ OPTIONS:
           Authentication token for a Coder agent. If this is set, then
           CODER_AGENT_URL must also be set.
 
-      --coder-agent-url url, $CODER_AGENT_URL
+      --coder-agent-url string, $CODER_AGENT_URL
           URL of the Coder deployment. If CODER_AGENT_TOKEN is also set, logs
           from envbuilder will be forwarded here and will be visible in the
           workspace build logs.


### PR DESCRIPTION
Workaround for https://github.com/coder/serpent/issues/14