### PR TITLE
feat: fetch SSH key from Coder if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ envbuilder will assume SSH authentication. You have the following options:
       ghcr.io/coder/envbuilder
    ```
 
+1. Fetch the SSH key from Coder: as long as `CODER_AGENT_URL` and
+   `CODER_AGENT_TOKEN` are set, then envbuilder will attempt to fetch the
+   corresponding Git SSH key directly from Coder. Example:
+
+   ```terraform
+    resource "docker_container" "workspace" {
+      count = data.coder_workspace.me.start_count
+      image = "ghcr.io/coder/envbuilder:version"
+      name  =
+      "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+
+      env = [
+        "CODER_AGENT_TOKEN=${coder_agent.dev.token}",
+        "CODER_AGENT_URL=${data.coder_workspace.me.access_url}",
+        ...
+      ]
+   ```
+
 1. Agent-based authentication: set `SSH_AUTH_SOCK` and mount in your agent socket, for example:
 
   ```bash

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -194,7 +194,7 @@ func Run(ctx context.Context, options Options) error {
 			CABundle:     caBundle,
 		}
 
-		cloneOpts.RepoAuth = SetupRepoAuth(&options)
+		cloneOpts.RepoAuth = SetupRepoAuth(ctx, &options)
 		if options.GitHTTPProxyURL != "" {
 			cloneOpts.ProxyOptions = transport.ProxyOptions{
 				URL: options.GitHTTPProxyURL,

--- a/git.go
+++ b/git.go
@@ -176,6 +176,13 @@ func LogHostKeyCallback(log LoggerFunc) gossh.HostKeyCallback {
 // If SSH_PRIVATE_KEY_PATH is set, an SSH private key will be read from
 // that path and the SSH auth method will be configured with that key.
 //
+// If no SSH_PRIVATE_KEY_PATH is set, but CODER_AGENT_URL and CODER_AGENT_TOKEN
+// are both specified, envbuilder will attempt to fetch the corresponding
+// Git SSH key for the user.
+//
+// Otherwise, SSH authentication will fall back to SSH_AUTH_SOCK, in which
+// case SSH_AUTH_SOCK must be set to the path of a listening SSH agent socket.
+//
 // If SSH_KNOWN_HOSTS is not set, the SSH auth method will be configured
 // to accept and log all host keys. Otherwise, host key checking will be
 // performed as usual.

--- a/git_test.go
+++ b/git_test.go
@@ -393,7 +393,7 @@ func TestSetupRepoAuth(t *testing.T) {
 		actualSigner, err := gossh.ParsePrivateKey([]byte(testKey))
 		require.NoError(t, err)
 		handler := func(w http.ResponseWriter, r *http.Request) {
-			hdr := r.Header.Get("Coder-Session-Token")
+			hdr := r.Header.Get(codersdk.SessionTokenHeader)
 			if !assert.Equal(t, hdr, token) {
 				w.WriteHeader(http.StatusForbidden)
 				return
@@ -409,10 +409,8 @@ func TestSetupRepoAuth(t *testing.T) {
 			}
 		}
 		srv := httptest.NewServer(http.HandlerFunc(handler))
-		u, err := url.Parse(srv.URL)
-		require.NoError(t, err)
 		opts := &envbuilder.Options{
-			CoderAgentURL:   u,
+			CoderAgentURL:   srv.URL,
 			CoderAgentToken: token,
 			GitURL:          "ssh://git@host.tld:repo/path",
 			Logger:          testLog(t),
@@ -427,13 +425,13 @@ func TestSetupRepoAuth(t *testing.T) {
 	t.Run("SSH/CoderForbidden", func(t *testing.T) {
 		token := uuid.NewString()
 		handler := func(w http.ResponseWriter, r *http.Request) {
+			hdr := r.Header.Get(codersdk.SessionTokenHeader)
+			assert.Equal(t, hdr, token)
 			w.WriteHeader(http.StatusForbidden)
 		}
 		srv := httptest.NewServer(http.HandlerFunc(handler))
-		u, err := url.Parse(srv.URL)
-		require.NoError(t, err)
 		opts := &envbuilder.Options{
-			CoderAgentURL:   u,
+			CoderAgentURL:   srv.URL,
 			CoderAgentToken: token,
 			GitURL:          "ssh://git@host.tld:repo/path",
 			Logger:          testLog(t),


### PR DESCRIPTION
Relates to https://github.com/coder/envbuilder/issues/31

Depends on https://github.com/coder/envbuilder/pull/173

Modifies the SSH logic introduced in https://github.com/coder/envbuilder/pull/170 with an extra step to fetch the SSH key from Coder.

There is currently a race condition between envbuilder starting and the workspace build being marked as 'completed'. To work around this, I added some backoff to fetching the SSH key using the agent token.

Demo:

https://github.com/coder/envbuilder/assets/4949514/986fc223-c50c-47dc-afc1-a251268cf0a0


