### PR TITLE
ci: update workflows to go 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.21"
+          go-version: "~1.22"
 
       - name: Test
         run: make test
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.21"
+          go-version: "~1.22"
 
       - name: Generate docs
         run: make docs
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.21"
+          go-version: "~1.22"
 
       - name: Check format
         run: ./scripts/check_fmt.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.21"
+          go-version: "~1.22"
 
       - name: Docker Login
         uses: docker/login-action@v2

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ On MacOS or Windows systems, we recommend either using a VM or the provided `.de
 
 **Additional Requirements:**
 
-- `go 1.21`
+- `go 1.22`
 - `make`
 - Docker daemon (for running tests)
 


### PR DESCRIPTION
- Update CI workflows to go 1.22
- Update README.md