### PR TITLE
fix: revert setting default UserID and GroupID to 0:0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.3
 
 // There are a few options we need added to Kaniko!
 // See: https://github.com/GoogleContainerTools/kaniko/compare/main...coder:kaniko:main
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240520100029-ba712f28f434
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240520141539-224e9a03f543
 
 require (
 	cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/coder/kaniko v0.0.0-20240520100029-ba712f28f434 h1:aqvehPc9tz7YZhlA/w67SMB2GG0dYYMPhFWQf40k3Jg=
-github.com/coder/kaniko v0.0.0-20240520100029-ba712f28f434/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
+github.com/coder/kaniko v0.0.0-20240520141539-224e9a03f543 h1:6SZ720cpgKywSWykyImM7kjgdB7cKS8Ydk65D8/WjWA=
+github.com/coder/kaniko v0.0.0-20240520141539-224e9a03f543/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/retry v1.5.1 h1:iWu8YnD8YqHs3XwqrqsjoBTAVqT9ml6z9ViJ2wlMiqc=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -94,7 +94,7 @@ func TestInitScriptInitCommand(t *testing.T) {
 }
 
 func TestUidGid(t *testing.T) {
-
+	t.Parallel()
 	t.Run("MultiStage", func(t *testing.T) {
 		t.Parallel()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -132,7 +132,7 @@ RUN printf "%%s\n" \
 	t.Run("SingleStage", func(t *testing.T) {
 		t.Parallel()
 
-		dockerFile := fmt.Sprintf(`FROM %s AS builder
+		dockerFile := fmt.Sprintf(`FROM %s
 RUN mkdir -p /myapp/somedir \
 && touch /myapp/somedir/somefile \
 && chown 123:123 /myapp/somedir \


### PR DESCRIPTION
After looking into the failing unit tests some more, it looks like https://github.com/coder/kaniko/commit/9f83bc8595cde0965de0b5a17e6770e5c2b1321f actually does cause divergence from Docker behaviour.

I've included an integration test adapted from GoogleContainerTools/kaniko that reproduces the issue. It affects file permissions when changing permissions in a multi-stage build but does not appear to affect single-stage builds.

This test fails with the commit, and succeeds without. The fix has not been merged upstream yet as it would break legacy users. For now, we will revert to the upstream behaviour.

This will unfortunately re-break https://github.com/coder/envbuilder/issues/70 but has a simple workaround of using `COPY --chown 0:0`.