### PR TITLE
feat: expose runtime markers

### DIFF
--- a/envbuilder_internal_test.go
+++ b/envbuilder_internal_test.go
@@ -27,7 +27,7 @@ func TestFindDevcontainerJSON(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("devcontainers.json is missing", func(t *testing.T) {
+	t.Run("devcontainer.json is missing", func(t *testing.T) {
 		t.Parallel()
 
 		// given

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -680,7 +680,10 @@ func TestContainerEnv(t *testing.T) {
 
 	output := execContainer(t, ctr, "cat /env")
 	require.Contains(t, strings.TrimSpace(output),
-		`FROM_CONTAINER_ENV=bar
+		`DEVCONTAINER=true
+DEVCONTAINER_CONFIG=/workspaces/empty/.devcontainer/devcontainer.json
+ENVBUILDER=true
+FROM_CONTAINER_ENV=bar
 FROM_DOCKERFILE=foo
 FROM_REMOTE_ENV=baz
 PATH=/usr/local/bin:/bin:/go/bin:/opt


### PR DESCRIPTION
Fixes: https://github.com/coder/envbuilder/issues/212

This PR adds logic to set extra environment variables to indicate the runtime.

See `DEVCONTAINER`, `ENVBUILDER`, and `DEVCONTAINER_CONFIG`:

```
root ➜ /workspaces/deno (main) $ env
DEVCONTAINER=true
HOSTNAME=da273e13e9d3
PWD=/workspaces/deno
HOME=/root
CARGO_HOME=/usr/local/cargo
DENO_INSTALL=/usr/local
TERM=xterm
RUSTUP_HOME=/usr/local/rustup
USER=root
INIT_SCRIPT=bash
GIT_URL=https://github.com/denoland/deno
SHLVL=1
PROMPT_DIRTRIM=4
KANIKO_DIR=/.envbuilder
ENVBUILDER=true
RUST_VERSION=1.78.0
PATH=/usr/local/cargo/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
DOCKER_CONFIG=/.envbuilder
DEVCONTAINER_CONFIG=/workspaces/deno/.devcontainer/devcontainer.json
_=/usr/bin/env
```