### PR TITLE
chore: integration: add test for pushing to cache repo that requires auth

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/envbuilder"
 	"github.com/coder/envbuilder/internal/notcodersdk"
 	"github.com/coder/envbuilder/testutil/gittest"
+	"github.com/coder/envbuilder/testutil/mwtest"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
@@ -82,7 +83,7 @@ func TestCloneRepo(t *testing.T) {
 			t.Run("AlreadyCloned", func(t *testing.T) {
 				srvFS := memfs.New()
 				_ = gittest.NewRepo(t, srvFS, gittest.Commit(t, "README.md", "Hello, world!", "Wow!"))
-				authMW := gittest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
+				authMW := mwtest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
 				srv := httptest.NewServer(authMW(gittest.NewServer(srvFS)))
 				clientFS := memfs.New()
 				// A repo already exists!
@@ -101,7 +102,7 @@ func TestCloneRepo(t *testing.T) {
 				t.Parallel()
 				srvFS := memfs.New()
 				_ = gittest.NewRepo(t, srvFS, gittest.Commit(t, "README.md", "Hello, world!", "Wow!"))
-				authMW := gittest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
+				authMW := mwtest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
 				srv := httptest.NewServer(authMW(gittest.NewServer(srvFS)))
 				clientFS := memfs.New()
 
@@ -134,7 +135,7 @@ func TestCloneRepo(t *testing.T) {
 				t.Parallel()
 				srvFS := memfs.New()
 				_ = gittest.NewRepo(t, srvFS, gittest.Commit(t, "README.md", "Hello, world!", "Wow!"))
-				authMW := gittest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
+				authMW := mwtest.BasicAuthMW(tc.srvUsername, tc.srvPassword)
 				srv := httptest.NewServer(authMW(gittest.NewServer(srvFS)))
 
 				authURL, err := url.Parse(srv.URL)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coder/envbuilder"
 	"github.com/coder/envbuilder/devcontainer/features"
 	"github.com/coder/envbuilder/testutil/gittest"
+	"github.com/coder/envbuilder/testutil/mwtest"
 	"github.com/coder/envbuilder/testutil/registrytest"
 	clitypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
@@ -1362,7 +1363,7 @@ func setupInMemoryRegistry(t *testing.T, opts setupInMemoryRegistryOpts) string 
 	t.Helper()
 	tempDir := t.TempDir()
 	regHandler := registry.New(registry.WithBlobHandler(registry.NewDiskBlobHandler(tempDir)))
-	authHandler := gittest.BasicAuthMW(opts.Username, opts.Password)(regHandler)
+	authHandler := mwtest.BasicAuthMW(opts.Username, opts.Password)(regHandler)
 	regSrv := httptest.NewServer(authHandler)
 	t.Cleanup(func() { regSrv.Close() })
 	regSrvURL, err := url.Parse(regSrv.URL)
@@ -1409,7 +1410,7 @@ type gitServerOptions struct {
 func createGitServer(t *testing.T, opts gitServerOptions) *httptest.Server {
 	t.Helper()
 	if opts.authMW == nil {
-		opts.authMW = gittest.BasicAuthMW(opts.username, opts.password)
+		opts.authMW = mwtest.BasicAuthMW(opts.username, opts.password)
 	}
 	commits := make([]gittest.CommitFunc, 0)
 	for path, content := range opts.files {

--- a/testutil/gittest/gittest.go
+++ b/testutil/gittest/gittest.go
@@ -249,18 +249,3 @@ func WriteFile(t *testing.T, fs billy.Filesystem, path, content string) {
 	err = file.Close()
 	require.NoError(t, err)
 }
-
-func BasicAuthMW(username, password string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if username != "" || password != "" {
-				authUser, authPass, ok := r.BasicAuth()
-				if !ok || username != authUser || password != authPass {
-					w.WriteHeader(http.StatusUnauthorized)
-					return
-				}
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
-}

--- a/testutil/mwtest/auth_basic.go
+++ b/testutil/mwtest/auth_basic.go
@@ -1,0 +1,18 @@
+package mwtest
+
+import "net/http"
+
+func BasicAuthMW(username, password string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if username != "" || password != "" {
+				authUser, authPass, ok := r.BasicAuth()
+				if !ok || username != authUser || password != authPass {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
Adds a gap in our testing for the case when the cache repo requires auth.
NOTE: this shows that being unable to push the image will fail the build outright.
Do we maybe want to relax this?