### PR TITLE
fix: fix unsetOptionsEnv, add integration test

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1069,6 +1069,7 @@ func unsetOptionsEnv() {
 			continue
 		}
 		// Do not strip options that do not have the magic prefix!
+		// For example, CODER_AGENT_URL, CODER_AGENT_TOKEN, CODER_AGENT_SUBSYSTEM.
 		if !strings.HasPrefix(opt.Env, envPrefix) {
 			continue
 		}

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1064,16 +1063,13 @@ func createPostStartScript(path string, postStartCommand devcontainer.LifecycleS
 // unsetOptionsEnv unsets all environment variables that are used
 // to configure the options.
 func unsetOptionsEnv() {
-	val := reflect.ValueOf(&Options{}).Elem()
-	typ := val.Type()
-
-	for i := 0; i < val.NumField(); i++ {
-		fieldTyp := typ.Field(i)
-		env := fieldTyp.Tag.Get("env")
-		if env == "" {
+	var o Options
+	for _, opt := range o.CLI() {
+		if opt.Env == "" {
 			continue
 		}
-		os.Unsetenv(env)
+		os.Unsetenv(opt.Env)
+		os.Unsetenv(strings.TrimPrefix(opt.Env, envPrefix))
 	}
 }
 

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1068,6 +1068,11 @@ func unsetOptionsEnv() {
 		if opt.Env == "" {
 			continue
 		}
+		// Do not strip options that do not have the magic prefix!
+		if !strings.HasPrefix(opt.Env, envPrefix) {
+			continue
+		}
+		// Strip both with and without prefix.
 		os.Unsetenv(opt.Env)
 		os.Unsetenv(strings.TrimPrefix(opt.Env, envPrefix))
 	}


### PR DESCRIPTION
Introduced in https://github.com/coder/envbuilder/pull/140

Updates `unsetOptionsEnv` to use the correct value and adds an integration test to ensure envs are unset in init script.