### PR TITLE
fix(devcontainer): correctly parse feature with digest

### DIFF
--- a/devcontainer/devcontainer.go
+++ b/devcontainer/devcontainer.go
@@ -256,11 +256,11 @@ func (s *Spec) compileFeatures(fs billy.Filesystem, devcontainerDir, scratchDir 
 			ok         bool
 		)
 		if _, featureRef, ok = strings.Cut(featureRefRaw, "./"); !ok {
-			featureRefParsed, err := name.NewTag(featureRefRaw)
+			featureRefParsed, err := name.ParseReference(featureRefRaw)
 			if err != nil {
 				return "", nil, fmt.Errorf("parse feature ref %s: %w", featureRefRaw, err)
 			}
-			featureRef = featureRefParsed.Repository.Name()
+			featureRef = featureRefParsed.Context().Name()
 		}
 
 		featureOpts := map[string]any{}


### PR DESCRIPTION
Hello! 👋

Parsing an image with a digest like `ghcr.io/coder/envbuilder:0.2.9@sha256:b51153d8cc1235986707d5f61949884444f2b4c4f64b15b5506cb5484bfa8a93` using `NewTag` does not work:

```
repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: coder/envbuilder:0.2.9@sha256
```

`ParseReference` supports both tag and digest, and produces the same result.