### PR TITLE
feat: prefix cached image with ENVBUILDER_CACHED_IMAGE in log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,30 @@ docker run -it --rm \
 
 Each layer is stored in the registry as a separate image. The image tag is the hash of the layer's contents. The image digest is the hash of the image tag. The image digest is used to pull the layer from the registry.
 
-The performance improvement of builds depends on the complexity of your Dockerfile. For [`coder/coder`](https://github.com/coder/coder/blob/main/.devcontainer/Dockerfile), uncached builds take 36m while cached builds take 40s (~98% improvement).
+The performance improvement of builds depends on the complexity of your
+Dockerfile. For
+[`coder/coder`](https://github.com/coder/coder/blob/main/.devcontainer/Dockerfile),
+uncached builds take 36m while cached builds take 40s (~98% improvement).
+
+## Pushing the built image
+
+Set `ENVBUILDER_PUSH_IMAGE=1` to push the entire image to the cache repo
+in addition to individual layers. `ENVBUILDER_CACHE_REPO` **must** be set in
+order for this to work.
+
+> **Note:** this option forces Envbuilder to perform a "reproducible" build.
+> This will force timestamps for all newly added files to be set to the start of the UNIX epoch.
+
+## Probe Layer Cache
+
+To check for the presence of a pre-built image, set
+`ENVBUILDER_GET_CACHED_IMAGE=1`. Instead of building the image, this will
+perform a "dry-run" build of the image, consulting `ENVBUILDER_CACHE_REPO` for
+each layer.
+
+If any layer is found not to be present in the cache repo, envbuilder
+will exit with an error. Otherwise, the image will be emitted in the log output prefixed with the string
+`ENVBUILDER_CACHED_IMAGE=...`.
 
 ## Image Caching
 

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -566,7 +566,7 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 				return nil, xerrors.Errorf("get cached image digest: %w", err)
 			}
 			endStage("🏗️ Found cached image!")
-			_, _ = fmt.Fprintf(os.Stdout, "%s@%s\n", options.CacheRepo, digest.String())
+			_, _ = fmt.Fprintf(os.Stdout, "ENVBUILDER_CACHED_IMAGE=%s@%s\n", options.CacheRepo, digest.String())
 			os.Exit(0)
 		}
 


### PR DESCRIPTION
When running `ENVBUILDER_GET_CACHED_IMAGE`, prefixes the cached image with the string `ENVBUILDER_CACHED_IMAGE=`.

This can then be consumed more easily e.g.

```
resource "docker_container" "check_cache" {                                                                                                                                                                   
  image = var.envbuilder_image
  name = "envbuilder-get-cached-image"
  attach = true
  logs = true
  must_run = false
  network_mode = "host"
  env = [ 
    "ENVBUILDER_GIT_URL=${var.git_repo}",
    "ENVBUILDER_DEVCONTAINER_DIR=${var.devcontainer_dir}",
    "ENVBUILDER_GET_CACHED_IMAGE=1",
    "ENVBUILDER_CACHE_REPO=localhost:5000/envbuilder-cache",
  ]
}

locals {
  logs = docker_container.check_cache.container_logs
  regex_match = try(regex("ENVBUILDER_CACHED_IMAGE=([^\\S]+)", local.logs), [""])
  cached_image_ref = local.regex_match[0]
}
 
resource "docker_container" "cached" {
  image = coalesce(local.cached_image_ref, var.envbuilder_image)
  name = "envbuilder-workspace"
  network_mode = "host"
  env = [ 
    "ENVBUILDER_GIT_URL=${var.git_repo}",
    "ENVBUILDER_DEVCONTAINER_DIR=${var.devcontainer_dir}",
    "ENVBUILDER_INIT_SCRIPT=sleep infinity",
    "ENVBUILDER_PUSH_IMAGE=1",
    "ENVBUILDER_CACHE_REPO=localhost:5000/envbuilder-cache",
  ]
}
```