### PR TITLE
fix(remount): relocate libraries along with their symlinks

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -438,7 +438,7 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 	tempRemountDest := filepath.Join("/", MagicDir, "mnt")
 	// ignorePrefixes is a superset of ignorePaths that we pass to kaniko's
 	// IgnoreList.
-	ignorePrefixes := append([]string{"/proc", "/sys"}, ignorePaths...)
+	ignorePrefixes := append([]string{"/dev", "/proc", "/sys"}, ignorePaths...)
 	restoreMounts, err := ebutil.TempRemount(options.Logger, tempRemountDest, ignorePrefixes...)
 	defer func() { // restoreMounts should never be nil
 		if err := restoreMounts(); err != nil {

--- a/internal/ebutil/libs.go
+++ b/internal/ebutil/libs.go
@@ -1,0 +1,78 @@
+package ebutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L29
+
+const usrLibDir = "/usr/lib64"
+
+const debianVersionFile = "/etc/debian_version"
+
+// getLibDir returns the library directory. It returns a multiarch directory if
+// the distribution is Debian or a derivative.
+//
+// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/nvc_container.c#L152-L165
+func getLibDir(m mounter) (string, error) {
+	// Debian and its derivatives use a multiarch directory scheme.
+	if _, err := m.Stat(debianVersionFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("check if debian: %w", err)
+	} else if err == nil {
+		return usrLibMultiarchDir, nil
+	}
+
+	return usrLibDir, nil
+}
+
+// getLibsSymlinks returns the stats for all library symlinks if the library
+// directory exists.
+func getLibsSymlinks(m mounter, libDir string) (map[string][]string, error) {
+	des, err := m.ReadDir(libDir)
+	if err != nil {
+		return nil, fmt.Errorf("read directory %s: %w", libDir, err)
+	}
+
+	libsSymlinks := make(map[string][]string)
+	for _, de := range des {
+		if de.IsDir() {
+			continue
+		}
+
+		if de.Type()&os.ModeSymlink != os.ModeSymlink {
+			// Not a symlink. Skip.
+			continue
+		}
+
+		symlink := filepath.Join(libDir, de.Name())
+		path, err := m.EvalSymlinks(symlink)
+		if err != nil {
+			return nil, fmt.Errorf("eval symlink %s: %w", symlink, err)
+		}
+
+		path = filepath.Base(path)
+
+		if _, ok := libsSymlinks[path]; !ok {
+			libsSymlinks[path] = make([]string, 0, 1)
+		}
+
+		libsSymlinks[path] = append(libsSymlinks[path], de.Name())
+	}
+
+	return libsSymlinks, nil
+}
+
+// moveLibSymlinks moves a list of symlinks from source to destination directory.
+func moveLibSymlinks(m mounter, symlinks []string, srcDir, destDir string) error {
+	for _, l := range symlinks {
+		oldpath := filepath.Join(srcDir, l)
+		newpath := filepath.Join(destDir, l)
+		if err := m.Rename(oldpath, newpath); err != nil {
+			return fmt.Errorf("move symlink %s => %s: %w", oldpath, newpath, err)
+		}
+	}
+	return nil
+}

--- a/internal/ebutil/libs_amd64.go
+++ b/internal/ebutil/libs_amd64.go
@@ -1,0 +1,7 @@
+//go:build amd64
+
+package ebutil
+
+// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L36
+
+const usrLibMultiarchDir = "/usr/lib/x86_64-linux-gnu"

--- a/internal/ebutil/libs_arm64.go
+++ b/internal/ebutil/libs_arm64.go
@@ -1,0 +1,7 @@
+//go:build arm64
+
+package ebutil
+
+// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L52
+
+const usrLibMultiarchDir = "/usr/lib/aarch64-linux-gnu"

--- a/internal/ebutil/libs_ppc64le.go
+++ b/internal/ebutil/libs_ppc64le.go
@@ -1,7 +1,0 @@
-//go:build ppc64le
-
-package ebutil
-
-// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L44
-
-const usrLibMultiarchDir = "/usr/lib/powerpc64le-linux-gnu"

--- a/internal/ebutil/libs_ppc64le.go
+++ b/internal/ebutil/libs_ppc64le.go
@@ -1,0 +1,7 @@
+//go:build ppc64le
+
+package ebutil
+
+// Based on https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L44
+
+const usrLibMultiarchDir = "/usr/lib/powerpc64le-linux-gnu"

--- a/internal/ebutil/mock_mounter_test.go
+++ b/internal/ebutil/mock_mounter_test.go
@@ -42,6 +42,21 @@ func (m *Mockmounter) EXPECT() *MockmounterMockRecorder {
 	return m.recorder
 }
 
+// EvalSymlinks mocks base method.
+func (m *Mockmounter) EvalSymlinks(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvalSymlinks", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EvalSymlinks indicates an expected call of EvalSymlinks.
+func (mr *MockmounterMockRecorder) EvalSymlinks(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvalSymlinks", reflect.TypeOf((*Mockmounter)(nil).EvalSymlinks), arg0)
+}
+
 // GetMounts mocks base method.
 func (m *Mockmounter) GetMounts() ([]*procfs.MountInfo, error) {
 	m.ctrl.T.Helper()
@@ -98,6 +113,35 @@ func (m *Mockmounter) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (*os.Fil
 func (mr *MockmounterMockRecorder) OpenFile(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*Mockmounter)(nil).OpenFile), arg0, arg1, arg2)
+}
+
+// ReadDir mocks base method.
+func (m *Mockmounter) ReadDir(arg0 string) ([]os.DirEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", arg0)
+	ret0, _ := ret[0].([]os.DirEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir.
+func (mr *MockmounterMockRecorder) ReadDir(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*Mockmounter)(nil).ReadDir), arg0)
+}
+
+// Rename mocks base method.
+func (m *Mockmounter) Rename(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rename", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Rename indicates an expected call of Rename.
+func (mr *MockmounterMockRecorder) Rename(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*Mockmounter)(nil).Rename), arg0, arg1)
 }
 
 // Stat mocks base method.

--- a/internal/ebutil/remount.go
+++ b/internal/ebutil/remount.go
@@ -45,12 +45,12 @@ func tempRemount(m mounter, logf func(notcodersdk.LogLevel, string, ...any), bas
 		return func() error { return nil }, fmt.Errorf("get mounts: %w", err)
 	}
 
-	libDir, err := getLibDir(m)
+	libDir, err := libraryDirectoryPath(m)
 	if err != nil {
 		return func() error { return nil }, fmt.Errorf("get lib directory: %w", err)
 	}
 
-	libsSymlinks, err := getLibsSymlinks(m, libDir)
+	libsSymlinks, err := libraryDirectorySymlinks(m, libDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return func() error { return nil }, fmt.Errorf("read lib symlinks: %w", err)
 	}
@@ -66,7 +66,7 @@ func tempRemount(m mounter, logf func(notcodersdk.LogLevel, string, ...any), bas
 				return
 			}
 
-			newLibDir, err := getLibDir(m)
+			newLibDir, err := libraryDirectoryPath(m)
 			if err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("get new lib directory: %w", err))
 				return
@@ -137,6 +137,7 @@ func remount(m mounter, src, dest, libDir string, libsSymlinks map[string][]stri
 		if err != nil {
 			return fmt.Errorf("ensure file path: %w", err)
 		}
+		// This ensure the file is created, it will not be used. It can be closed immediately.
 		f.Close()
 
 		if symlinks, ok := libsSymlinks[stat.Name()]; ok {
@@ -154,7 +155,6 @@ func remount(m mounter, src, dest, libDir string, libsSymlinks map[string][]stri
 	if err := m.Unmount(src, 0); err != nil {
 		return fmt.Errorf("unmount orig src %s: %w", src, err)
 	}
-
 	return nil
 }
 

--- a/internal/ebutil/remount_internal_test.go
+++ b/internal/ebutil/remount_internal_test.go
@@ -2,6 +2,7 @@ package ebutil
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -15,6 +16,12 @@ import (
 	"github.com/prometheus/procfs"
 )
 
+var expectedLibMultiarchDir = map[string]string{
+	"amd64":   "/usr/lib/x86_64-linux-gnu",
+	"arm64":   "/usr/lib/aarch64-linux-gnu",
+	"ppc64le": "/usr/lib/powerpc64le-linux-gnu",
+}
+
 func Test_tempRemount(t *testing.T) {
 	t.Parallel()
 
@@ -26,11 +33,14 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(nil)
-		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/.test/var/lib/modules", "/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/.test/var/lib/modules", 0).Times(1).Return(nil)
@@ -51,16 +61,215 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/usr/bin/utility:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/usr/bin/utility").Return(&fakeFileInfo{isDir: false}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
 		mm.EXPECT().MkdirAll("/.test/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().OpenFile("/.test/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
 		mm.EXPECT().Mount("/usr/bin/utility", "/.test/usr/bin/utility", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/usr/bin/utility", 0).Times(1).Return(nil)
-		mm.EXPECT().Stat("/.test/usr/bin/utility").Return(&fakeFileInfo{isDir: false}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
 		mm.EXPECT().MkdirAll("/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().OpenFile("/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
 		mm.EXPECT().Mount("/.test/usr/bin/utility", "/usr/bin/utility", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/.test/usr/bin/utility", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLib", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("/usr/lib64/lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("/usr/lib64/lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test/usr/lib64/lib.so", "/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibDebian", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, nil)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll(expectedLibMultiarchDir[runtime.GOARCH], os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test/usr/lib64/lib.so", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibFromDebianToNotDebian", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, nil)
+		mm.EXPECT().ReadDir(expectedLibMultiarchDir[runtime.GOARCH]).Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks(expectedLibMultiarchDir[runtime.GOARCH]+"/lib-other.so").Return(expectedLibMultiarchDir[runtime.GOARCH]+"/usr/lib64/lib-other.so.1", nil)
+		mm.EXPECT().Stat(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test"+expectedLibMultiarchDir[runtime.GOARCH], os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so", "/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(nil)
+		mm.EXPECT().Mount(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so", "/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibNoSymlink", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+		}, nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
 
 		remount, err := tempRemount(mm, fakeLog(t), "/.test")
 		require.NoError(t, err)
@@ -78,6 +287,8 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
 
 		remount, err := tempRemount(mm, fakeLog(t), "/.test", "/var/lib")
 		require.NoError(t, err)
@@ -97,6 +308,39 @@ func Test_tempRemount(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ErrStatDebianVersion", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.ErrorContains(t, err, assert.AnError.Error())
+		err = remount()
+		require.NoError(t, err)
+	})
+
+	t.Run("ErrReadLibDir", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.ErrorContains(t, err, assert.AnError.Error())
+		err = remount()
+		require.NoError(t, err)
+	})
+
 	t.Run("ErrMkdirAll", func(t *testing.T) {
 		t.Parallel()
 
@@ -105,8 +349,73 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.ErrorContains(t, err, assert.AnError.Error())
+		err = remount()
+		require.NoError(t, err)
+	})
+
+	t.Run("ErrOpenFile", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/bin/utility:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(nil, assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.ErrorContains(t, err, assert.AnError.Error())
+		err = remount()
+		require.NoError(t, err)
+	})
+
+	t.Run("ErrMoveSymlink", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(assert.AnError)
 
 		remount, err := tempRemount(mm, fakeLog(t), "/.test")
 		require.ErrorContains(t, err, assert.AnError.Error())
@@ -122,7 +431,9 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(assert.AnError)
 
@@ -140,7 +451,9 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(assert.AnError)
@@ -151,6 +464,28 @@ func Test_tempRemount(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ErrRemountStatDebianVersion", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
+		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.ErrorContains(t, err, assert.AnError.Error())
+	})
+
 	t.Run("ErrRemountMkdirAll", func(t *testing.T) {
 		t.Parallel()
 
@@ -159,12 +494,91 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(nil)
-		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/var/lib/modules", os.FileMode(0o750)).Times(1).Return(assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.ErrorContains(t, err, assert.AnError.Error())
+	})
+
+	t.Run("ErrRemountOpenFile", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/bin/utility:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/usr/bin/utility", "/.test/usr/bin/utility", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/bin/utility", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(nil, assert.AnError)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.ErrorContains(t, err, assert.AnError.Error())
+	})
+
+	t.Run("ErrRemountMoveSymlink", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:ro", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("/usr/lib64/lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("/usr/lib64/lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test/usr/lib64/lib.so", "/usr/lib64/lib.so").Return(assert.AnError)
 
 		remount, err := tempRemount(mm, fakeLog(t), "/.test")
 		require.NoError(t, err)
@@ -180,11 +594,14 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(nil)
-		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/.test/var/lib/modules", "/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(assert.AnError)
 
@@ -202,11 +619,14 @@ func Test_tempRemount(t *testing.T) {
 		mounts := fakeMounts("/home", "/var/lib/modules:ro", "/proc", "/sys")
 
 		mm.EXPECT().GetMounts().Return(mounts, nil)
-		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/.test/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/var/lib/modules", "/.test/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/var/lib/modules", 0).Times(1).Return(nil)
-		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{isDir: true}, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/var/lib/modules").Return(&fakeFileInfo{name: "modules", isDir: true}, nil)
 		mm.EXPECT().MkdirAll("/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/.test/var/lib/modules", "/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/.test/var/lib/modules", 0).Times(1).Return(assert.AnError)
@@ -241,10 +661,11 @@ func fakeLog(t *testing.T) func(notcodersdk.LogLevel, string, ...any) {
 }
 
 type fakeFileInfo struct {
+	name  string
 	isDir bool
 }
 
-func (fi *fakeFileInfo) Name() string       { return "" }
+func (fi *fakeFileInfo) Name() string       { return fi.name }
 func (fi *fakeFileInfo) Size() int64        { return 0 }
 func (fi *fakeFileInfo) Mode() os.FileMode  { return 0 }
 func (fi *fakeFileInfo) ModTime() time.Time { return time.Time{} }
@@ -252,3 +673,16 @@ func (fi *fakeFileInfo) IsDir() bool        { return fi.isDir }
 func (fi *fakeFileInfo) Sys() any           { return nil }
 
 var _ os.FileInfo = &fakeFileInfo{}
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+	mode  os.FileMode
+}
+
+func (de *fakeDirEntry) Name() string               { return de.name }
+func (de *fakeDirEntry) IsDir() bool                { return de.isDir }
+func (de *fakeDirEntry) Type() os.FileMode          { return de.mode }
+func (de *fakeDirEntry) Info() (os.FileInfo, error) { return nil, nil }
+
+var _ os.DirEntry = &fakeDirEntry{}

--- a/internal/ebutil/remount_internal_test.go
+++ b/internal/ebutil/remount_internal_test.go
@@ -17,9 +17,8 @@ import (
 )
 
 var expectedLibMultiarchDir = map[string]string{
-	"amd64":   "/usr/lib/x86_64-linux-gnu",
-	"arm64":   "/usr/lib/aarch64-linux-gnu",
-	"ppc64le": "/usr/lib/powerpc64le-linux-gnu",
+	"amd64": "/usr/lib/x86_64-linux-gnu",
+	"arm64": "/usr/lib/aarch64-linux-gnu",
 }
 
 func Test_tempRemount(t *testing.T) {


### PR DESCRIPTION
This PR adds:

1. Look up the library directory, the value differs for Debian-based distros (the initial envbuilder image is non-Debian, but the final image may be Debian)
2. Find the symlinks pointing to mounts in the library directory
3. Temporarily move the library symlinks pointing to mounts to the magic directory while relocating the mounts
4. Look up the new library directory (in case it has changed)
5. Move back the library symlinks and mounts to the new library directory

After that the container should behave like a regular container created by the NVIDIA container runtime. Of course/unfortunately, the process of mounting/unmounting requires GPU containers to run with privileges:

> Appropriate privilege (Linux: the `CAP_SYS_ADMIN` capability) is required to mount/umount filesystems.

https://www.man7.org/linux/man-pages/man2/mount.2.html
https://www.man7.org/linux/man-pages/man2/umount.2.html

The logic is not generalized to any symlinks or any directories, it only aims at providing compatibility with the NVIDIA container runtime for now.

More context can be found in this comment https://github.com/coder/envbuilder/issues/143#issuecomment-2192405828

Tested with the following images:

* `docker.io/library/debian:bookworm`
* `docker.io/library/fedora:40`
* `nvcr.io/nvidia/pytorch:24.05-py3`

Closes #143