### PR TITLE
fix(remount): correct usrLibMultiarchDir value for 32-bit ARM

### DIFF
--- a/internal/ebutil/libs_arm.go
+++ b/internal/ebutil/libs_arm.go
@@ -2,5 +2,6 @@
 
 package ebutil
 
-// Based on a 32-bit Raspbian system.
-const usrLibMultiarchDir = "/usr/lib/arm-linux-gnueabihf"
+// This constant is for 64-bit systems. 32-bit ARM is not supported.
+// If ever it becomes supported, it should be handled with a `usrLib32MultiarchDir` constant.
+const usrLibMultiarchDir = "/var/empty"

--- a/internal/ebutil/remount_internal_test.go
+++ b/internal/ebutil/remount_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 var expectedLibMultiarchDir = map[string]string{
 	"amd64": "/usr/lib/x86_64-linux-gnu",
+	"arm":   "/var/empty",
 	"arm64": "/usr/lib/aarch64-linux-gnu",
 }
 


### PR DESCRIPTION
This constant is for 64-bit systems. 32-bit ARM is not supported.
If ever it becomes supported, it should be handled with a `usrLib32MultiarchDir` constant.

Using `/var/empty` for unsupported directories like NVIDIA: https://github.com/NVIDIA/libnvidia-container/blob/v1.15.0/src/common.h#L53

Follow up to #258