### PR TITLE
chore: update kaniko fork for better cache probing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 // There are a few options we need added to Kaniko!
 // See: https://github.com/GoogleContainerTools/kaniko/compare/main...coder:kaniko:main
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240624091120-7208a49f5b15
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3
 
 // Required to import codersdk due to gvisor dependency.
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20240702054557-aa558fbe5374

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352 h1:L/EjCuZxs5tOcqqCaASj/nu65TRYEFcTt8qRQfHZXX0=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352/go.mod h1:P1KoQSgnKEAG6Mnd3YlGzAophty+yKA9VV48LpfNRvo=
-github.com/coder/kaniko v0.0.0-20240624091120-7208a49f5b15 h1:Rne2frxrqtLEQ/v4f/wS550Yp/WXLCRFzDuxg8b9woM=
-github.com/coder/kaniko v0.0.0-20240624091120-7208a49f5b15/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
+github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3 h1:Q7L6cjKfw3DIyhKIcgCJEmgxnUTBajmMDrHxXvxgBZs=
+github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1065,7 +1065,13 @@ func TestPushImage(t *testing.T) {
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {
@@ -1089,7 +1095,7 @@ func TestPushImage(t *testing.T) {
 			envbuilderEnv("CACHE_REPO", testRepo),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 		}})
-		require.ErrorContains(t, err, "error probing build cache: uncached command")
+		require.ErrorContains(t, err, "error probing build cache: uncached RUN command")
 		// Then: it should fail to build the image and nothing should be pushed
 		_, err = remote.Image(ref)
 		require.ErrorContains(t, err, "NAME_UNKNOWN", "expected image to not be present before build + push")
@@ -1119,7 +1125,13 @@ func TestPushImage(t *testing.T) {
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {
@@ -1143,7 +1155,7 @@ func TestPushImage(t *testing.T) {
 			envbuilderEnv("CACHE_REPO", testRepo),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 		}})
-		require.ErrorContains(t, err, "error probing build cache: uncached command")
+		require.ErrorContains(t, err, "error probing build cache: uncached RUN command")
 		// Then: it should fail to build the image and nothing should be pushed
 		_, err = remote.Image(ref)
 		require.ErrorContains(t, err, "NAME_UNKNOWN", "expected image to not be present before build + push")
@@ -1232,7 +1244,13 @@ func TestPushImage(t *testing.T) {
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {
@@ -1270,7 +1288,7 @@ func TestPushImage(t *testing.T) {
 			envbuilderEnv("CACHE_REPO", testRepo),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 		}})
-		require.ErrorContains(t, err, "error probing build cache: uncached command")
+		require.ErrorContains(t, err, "error probing build cache: uncached RUN command")
 		// Then: it should fail to build the image and nothing should be pushed
 		_, err = remote.Image(ref, remoteAuthOpt)
 		require.ErrorContains(t, err, "NAME_UNKNOWN", "expected image to not be present before build + push")
@@ -1303,7 +1321,13 @@ func TestPushImage(t *testing.T) {
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {
@@ -1332,7 +1356,7 @@ func TestPushImage(t *testing.T) {
 			envbuilderEnv("CACHE_REPO", testRepo),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 		}})
-		require.ErrorContains(t, err, "error probing build cache: uncached command")
+		require.ErrorContains(t, err, "error probing build cache: uncached RUN command")
 		// Then: it should fail to build the image and nothing should be pushed
 		_, err = remote.Image(ref, remoteAuthOpt)
 		require.ErrorContains(t, err, "NAME_UNKNOWN", "expected image to not be present before build + push")
@@ -1386,7 +1410,7 @@ COPY --from=a /root/date.txt /date.txt`, testImageAlpine, testImageAlpine),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 			envbuilderEnv("DOCKERFILE_PATH", "Dockerfile"),
 		}})
-		require.ErrorContains(t, err, "error probing build cache: uncached command")
+		require.ErrorContains(t, err, "error probing build cache: uncached RUN command")
 		// Then: it should fail to build the image and nothing should be pushed
 		_, err = remote.Image(ref)
 		require.ErrorContains(t, err, "NAME_UNKNOWN", "expected image to not be present before build + push")
@@ -1422,7 +1446,13 @@ COPY --from=a /root/date.txt /date.txt`, testImageAlpine, testImageAlpine),
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {
@@ -1448,7 +1478,13 @@ COPY --from=a /root/date.txt /date.txt`, testImageAlpine, testImageAlpine),
 
 		srv := createGitServer(t, gitServerOptions{
 			files: map[string]string{
-				".devcontainer/Dockerfile": fmt.Sprintf("FROM %s\nRUN date --utc > /root/date.txt", testImageAlpine),
+				".devcontainer/Dockerfile": fmt.Sprintf(`FROM %s
+USER root
+ARG WORKDIR=/
+WORKDIR $WORKDIR
+ENV FOO=bar
+RUN echo $FOO > /root/foo.txt
+RUN date --utc > /root/date.txt`, testImageAlpine),
 				".devcontainer/devcontainer.json": `{
 				"name": "Test",
 				"build": {


### PR DESCRIPTION
This PR updates our kaniko fork to pull in https://github.com/coder/kaniko/pull/17 and fix https://github.com/coder/envbuilder/issues/254.

Added a few more directives to our integration test Dockerfiles to catch these types of scenarios.
