### PR TITLE
fix(envbuilder): add /product_uuid and /product_name to IgnorePaths by default

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, options Options) error {
 	// Once the legacy environment variables are phased out, this can be
 	// reinstated to the previous default values.
 	if len(options.IgnorePaths) == 0 {
-		options.IgnorePaths = []string{"/var/run"}
+		options.IgnorePaths = []string{"/var/run", "/product_uuid", "/product_name"}
 	}
 	if options.InitScript == "" {
 		options.InitScript = "sleep infinity"

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -89,7 +89,11 @@ func Run(ctx context.Context, options Options) error {
 	// Once the legacy environment variables are phased out, this can be
 	// reinstated to the previous default values.
 	if len(options.IgnorePaths) == 0 {
-		options.IgnorePaths = []string{"/var/run", "/product_uuid", "/product_name"}
+		options.IgnorePaths = []string{
+			"/var/run",
+			// KinD adds these paths to pods, so ignore them by default.
+			"/product_uuid", "/product_name",
+		}
 	}
 	if options.InitScript == "" {
 		options.InitScript = "sleep infinity"


### PR DESCRIPTION
KinD adds `/product_uuid` and `/product_name` to pods. Add these to Envbuilder's default ignore list as they otherwise cause issues in KinD.