### PR TITLE
extract RunCacheProbe function

### DIFF
--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -36,6 +36,7 @@ func envbuilderCmd() serpent.Command {
 		Use:     "envbuilder",
 		Options: o.CLI(),
 		Handler: func(inv *serpent.Invocation) error {
+			o.SetDefaults()
 			o.Logger = log.New(os.Stderr, o.Verbose)
 			if o.CoderAgentURL != "" {
 				if o.CoderAgentToken == "" {
@@ -61,6 +62,19 @@ func envbuilderCmd() serpent.Command {
 					// Failure to log to Coder should cause a fatal error.
 					o.Logger(log.LevelError, "unable to send logs to Coder: %s", err.Error())
 				}
+			}
+
+			if o.GetCachedImage {
+				img, err := envbuilder.RunCacheProbe(inv.Context(), o)
+				if err != nil {
+					o.Logger(log.LevelError, "error: %s", err)
+				}
+				digest, err := img.Digest()
+				if err != nil {
+					return fmt.Errorf("get cached image digest: %w", err)
+				}
+				_, _ = fmt.Fprintf(inv.Stdout, "ENVBUILDER_CACHED_IMAGE=%s@%s\n", o.CacheRepo, digest.String())
+				return nil
 			}
 
 			err := envbuilder.Run(inv.Context(), o)

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -60,6 +60,7 @@ type DockerConfig configfile.ConfigFile
 // Filesystem is the filesystem to use for all operations.
 // Defaults to the host filesystem.
 func Run(ctx context.Context, opts options.Options) error {
+	defer options.UnsetEnv()
 	if opts.GetCachedImage {
 		return fmt.Errorf("developer error: use RunCacheProbe instead")
 	}
@@ -834,6 +835,7 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 // RunCacheProbe performs a 'dry-run' build of the image and checks that
 // all of the resulting layers are present in options.CacheRepo.
 func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) {
+	defer options.UnsetEnv()
 	if !opts.GetCachedImage {
 		return nil, fmt.Errorf("developer error: RunCacheProbe must be run with --get-cached-image")
 	}

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -456,21 +456,6 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 			Reproducible: opts.PushImage,
 		}
 
-		if opts.GetCachedImage {
-			endStage := startStage("🏗️ Checking for cached image...")
-			image, err := executor.DoCacheProbe(kOpts)
-			if err != nil {
-				return nil, xerrors.Errorf("get cached image: %w", err)
-			}
-			digest, err := image.Digest()
-			if err != nil {
-				return nil, xerrors.Errorf("get cached image digest: %w", err)
-			}
-			endStage("🏗️ Found cached image!")
-			_, _ = fmt.Fprintf(os.Stdout, "ENVBUILDER_CACHED_IMAGE=%s@%s\n", kOpts.CacheRepo, digest.String())
-			os.Exit(0)
-		}
-
 		endStage := startStage("🏗️ Building image...")
 		image, err := executor.DoBuild(kOpts)
 		if err != nil {

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -431,7 +431,6 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 			// https://github.com/klauspost/compress/blob/67a538e2b4df11f8ec7139388838a13bce84b5d5/zstd/encoder_options.go#L188
 			CompressionLevel: 3,
 			CacheOptions: config.CacheOptions{
-				// Cache for a week by default!
 				CacheTTL: cacheTTL,
 				CacheDir: opts.BaseImageCacheDir,
 			},
@@ -840,9 +839,6 @@ ENTRYPOINT [%q]`, exePath, exePath, exePath)
 
 // RunCacheProbe performs a 'dry-run' build of the image and checks that
 // all of the resulting layers are present in options.CacheRepo.
-// Logger is the logf to use for all operations.
-// Filesystem is the filesystem to use for all operations.
-// Defaults to the host filesystem.
 func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) {
 	if !opts.GetCachedImage {
 		return nil, fmt.Errorf("developer error: RunCacheProbe must be run with --get-cached-image")
@@ -1128,7 +1124,6 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 		// https://github.com/klauspost/compress/blob/67a538e2b4df11f8ec7139388838a13bce84b5d5/zstd/encoder_options.go#L188
 		CompressionLevel: 3,
 		CacheOptions: config.CacheOptions{
-			// Cache for a week by default!
 			CacheTTL: cacheTTL,
 			CacheDir: opts.BaseImageCacheDir,
 		},

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -940,7 +940,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 		defer file.Close()
 		if opts.FallbackImage == "" {
 			if fallbackErr != nil {
-				return nil, xerrors.Errorf("%s: %w", fallbackErr.Error(), constants.ErrNoFallbackImage)
+				return nil, fmt.Errorf("%s: %w", fallbackErr.Error(), constants.ErrNoFallbackImage)
 			}
 			// We can't use errors.Join here because our tests
 			// don't support parsing a multiline error.
@@ -1152,7 +1152,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 	endStage := startStage("🏗️ Checking for cached image...")
 	image, err := executor.DoCacheProbe(kOpts)
 	if err != nil {
-		return nil, xerrors.Errorf("get cached image: %w", err)
+		return nil, fmt.Errorf("get cached image: %w", err)
 	}
 	endStage("🏗️ Found cached image!")
 
@@ -1388,17 +1388,17 @@ func maybeDeleteFilesystem(logger log.Func, force bool) error {
 func copyFile(src, dst string) error {
 	content, err := os.ReadFile(src)
 	if err != nil {
-		return xerrors.Errorf("read file failed: %w", err)
+		return fmt.Errorf("read file failed: %w", err)
 	}
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o755)
 	if err != nil {
-		return xerrors.Errorf("mkdir all failed: %w", err)
+		return fmt.Errorf("mkdir all failed: %w", err)
 	}
 
 	err = os.WriteFile(dst, content, 0o644)
 	if err != nil {
-		return xerrors.Errorf("write file failed: %w", err)
+		return fmt.Errorf("write file failed: %w", err)
 	}
 	return nil
 }
@@ -1409,15 +1409,15 @@ func initCABundle(sslCertBase64 string) ([]byte, error) {
 	}
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		return nil, xerrors.Errorf("get global system cert pool: %w", err)
+		return nil, fmt.Errorf("get global system cert pool: %w", err)
 	}
 	data, err := base64.StdEncoding.DecodeString(sslCertBase64)
 	if err != nil {
-		return nil, xerrors.Errorf("base64 decode ssl cert: %w", err)
+		return nil, fmt.Errorf("base64 decode ssl cert: %w", err)
 	}
 	ok := certPool.AppendCertsFromPEM(data)
 	if !ok {
-		return nil, xerrors.Errorf("failed to append the ssl cert to the global pool: %s", data)
+		return nil, fmt.Errorf("failed to append the ssl cert to the global pool: %s", data)
 	}
 	return data, nil
 }

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -101,7 +101,11 @@ func Run(ctx context.Context, opts options.Options) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = cleanupDockerConfigJSON() }() // best effort
+	defer func() {
+		if err := cleanupDockerConfigJSON(); err != nil {
+			opts.Logger(log.LevelError, "failed to cleanup docker config JSON: %w", err)
+		}
+	}() // best effort
 
 	var fallbackErr error
 	var cloned bool
@@ -860,7 +864,11 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = cleanupDockerConfigJSON() }() // best effort
+	defer func() {
+		if err := cleanupDockerConfigJSON(); err != nil {
+			opts.Logger(log.LevelError, "failed to cleanup docker config JSON: %w", err)
+		}
+	}() // best effort
 
 	var fallbackErr error
 	var cloned bool
@@ -1430,7 +1438,7 @@ func initDockerConfigJSON(dockerConfigBase64 string) (func() error, error) {
 				if !errors.Is(err, fs.ErrNotExist) {
 					cleanupErr = fmt.Errorf("remove docker config: %w", cleanupErr)
 				}
-				_, _ = fmt.Fprintln(os.Stderr, "failed to remove the Docker config secret file: %w", cfgPath)
+				_, _ = fmt.Fprintf(os.Stderr, "failed to remove the Docker config secret file: %s\n", cleanupErr)
 			}
 		})
 		return cleanupErr

--- a/envbuilder_test.go
+++ b/envbuilder_test.go
@@ -1,1 +1,0 @@
-package envbuilder_test


### PR DESCRIPTION
Part of https://github.com/coder/team-coconut/issues/11

Builds on top of https://github.com/coder/envbuilder/pull/282 and https://github.com/coder/envbuilder/pull/283

Extracts the logic for `--get-cached-image` to a separate function

Also pulls out some other common logic shared between `Run` and `RunCacheProbe`. There is more that could be DRYed up, but leaving this for later.