### PR TITLE
fix: always add COPY directives in DoCacheProbe

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1114,13 +1114,14 @@ RUN date --utc > /root/date.txt`, testImageAlpine),
 		_, err = remote.Image(ref)
 		require.ErrorContains(t, err, "MANIFEST_UNKNOWN", "expected image to not be present before build + push")
 
-		// Then: re-running envbuilder with GET_CACHED_IMAGE should succeed
+		// Then: re-running envbuilder with GET_CACHED_IMAGE should not succeed, as
+		// the envbuilder binary is not present in the pushed image.
 		_, err = runEnvbuilder(t, runOpts{env: []string{
 			envbuilderEnv("GIT_URL", srv.URL),
 			envbuilderEnv("CACHE_REPO", testRepo),
 			envbuilderEnv("GET_CACHED_IMAGE", "1"),
 		}})
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "uncached COPY command is not supported in cache probe mode")
 	})
 
 	t.Run("CacheAndPush", func(t *testing.T) {

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -55,4 +55,7 @@ func (o *Options) SetDefaults() {
 	if o.WorkspaceFolder == "" {
 		o.WorkspaceFolder = DefaultWorkspaceFolder(o.GitURL)
 	}
+	if o.BinaryPath == "" {
+		o.BinaryPath = "/.envbuilder/bin/envbuilder"
+	}
 }

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -85,6 +85,7 @@ func TestOptions_SetDefaults(t *testing.T) {
 		Filesystem:      chmodfs.New(osfs.New("/")),
 		GitURL:          "",
 		WorkspaceFolder: constants.EmptyWorkspaceDir,
+		BinaryPath:      "/.envbuilder/bin/envbuilder",
 	}
 
 	var actual options.Options

--- a/options/options.go
+++ b/options/options.go
@@ -156,6 +156,11 @@ type Options struct {
 	// used to improving cache utilization when multiple users are building
 	// working on the same repository.
 	RemoteRepoBuildMode bool
+
+	// BinaryPath is the path to the local envbuilder binary when
+	// attempting to probe the build cache. This is only relevant when
+	// GetCachedImage is true.
+	BinaryPath string
 }
 
 const envPrefix = "ENVBUILDER_"
@@ -426,6 +431,13 @@ func (o *Options) CLI() serpent.OptionSet {
 			Value: serpent.BoolOf(&o.GetCachedImage),
 			Description: "Print the digest of the cached image, if available. " +
 				"Exits with an error if not found.",
+		},
+		{
+			Flag:        "binary-path",
+			Env:         WithEnvPrefix("BINARY_PATH"),
+			Value:       serpent.StringOf(&o.BinaryPath),
+			Hidden:      true,
+			Description: "Specify the path to an Envbuilder binary for use when probing the build cache.",
 		},
 		{
 			Flag:    "remote-repo-build-mode",

--- a/options/options.go
+++ b/options/options.go
@@ -497,6 +497,9 @@ func (o *Options) Markdown() string {
 	_, _ = sb.WriteString("| - | - | - | - |\n")
 
 	for _, opt := range cliOptions {
+		if opt.Hidden {
+			continue
+		}
 		d := opt.Default
 		if d != "" {
 			d = "`" + d + "`"


### PR DESCRIPTION
Required in order to correctly handle RunCacheProbe. Without it, we will be unable to correctly detect the final layer of the built image.