### PR TITLE
feat: support starting from an already-built image

### DIFF
--- a/cmd/envbuilder/main.go
+++ b/cmd/envbuilder/main.go
@@ -68,6 +68,7 @@ func envbuilderCmd() serpent.Command {
 				img, err := envbuilder.RunCacheProbe(inv.Context(), o)
 				if err != nil {
 					o.Logger(log.LevelError, "error: %s", err)
+					return err
 				}
 				digest, err := img.Digest()
 				if err != nil {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 )
 
@@ -32,4 +33,25 @@ var (
 	// MagicFile is the location of the build context when
 	// using remote build mode.
 	MagicRemoteRepoDir = filepath.Join(MagicDir, "repo")
+
+	// MagicBinaryLocation is the expected location of the envbuilder binary
+	// inside a builder image.
+	MagicBinaryLocation = filepath.Join(MagicDir, "bin", "envbuilder")
+
+	// MagicImage is a file that is created in the image when
+	// envbuilder has already been run. This is used to skip
+	// the destructive initial build step when 'resuming' envbuilder
+	// from a previously built image.
+	MagicImage = filepath.Join(MagicDir, "image")
+
+	// MagicDirectives are directives automatically appended to Dockerfiles
+	// when pushing the image. These directives allow the built image to be
+	// 're-used'.
+	MagicDirectives = fmt.Sprintf(`
+COPY --chmod=0755 %[1]s %[2]s
+COPY --chmod=0644 %[3]s %[4]s
+USER root
+WORKDIR /
+ENTRYPOINT [%[2]q]
+`, filepath.Base(MagicBinaryLocation), MagicBinaryLocation, filepath.Base(MagicImage), MagicImage)
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -44,6 +44,10 @@ var (
 	// from a previously built image.
 	MagicImage = filepath.Join(MagicDir, "image")
 
+	// MagicTempDir is a directory inside the build context inside which
+	// we place files referenced by MagicDirectives.
+	MagicTempDir = ".envbuilder.tmp"
+
 	// MagicDirectives are directives automatically appended to Dockerfiles
 	// when pushing the image. These directives allow the built image to be
 	// 're-used'.
@@ -53,5 +57,8 @@ COPY --chmod=0644 %[3]s %[4]s
 USER root
 WORKDIR /
 ENTRYPOINT [%[2]q]
-`, filepath.Base(MagicBinaryLocation), MagicBinaryLocation, filepath.Base(MagicImage), MagicImage)
+`,
+		".envbuilder.tmp/envbuilder", MagicBinaryLocation,
+		".envbuilder.tmp/image", MagicImage,
+	)
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 // There are a few options we need added to Kaniko!
 // See: https://github.com/GoogleContainerTools/kaniko/compare/main...coder:kaniko:main
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240803153527-10d1800455b9
 
 // Required to import codersdk due to gvisor dependency.
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20240702054557-aa558fbe5374

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352 h1:L/EjCuZxs5tOcqqCaASj/nu65TRYEFcTt8qRQfHZXX0=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352/go.mod h1:P1KoQSgnKEAG6Mnd3YlGzAophty+yKA9VV48LpfNRvo=
-github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3 h1:Q7L6cjKfw3DIyhKIcgCJEmgxnUTBajmMDrHxXvxgBZs=
-github.com/coder/kaniko v0.0.0-20240717115058-0ba2908ca4d3/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
+github.com/coder/kaniko v0.0.0-20240803153527-10d1800455b9 h1:d01T5YbPN1yc1mXjIXG59YcQQoT/9idvqFErjWHfsZ4=
+github.com/coder/kaniko v0.0.0-20240803153527-10d1800455b9/go.mod h1:YMK7BlxerzLlMwihGxNWUaFoN9LXCij4P+w/8/fNlcM=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=


### PR DESCRIPTION
Fixes https://github.com/coder/envbuilder/issues/291

Depends on https://github.com/coder/kaniko/pull/19

Builds on top of https://github.com/coder/envbuilder/pull/292
- Extracts 'magic directives' to constants.go.
- Adds 'magic image' file to signify envbuilder should skip the destructive 'build image' stage.
- Modifies logic for copying binary into built image: we now copy to build context and remove it after build finishes to avoid leaving around files owned by `root:root`. Also ensures files are created with consistent permissions.