### PR TITLE
add hidden remote repo dir option to change clone path

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -138,7 +138,7 @@ func Run(ctx context.Context, opts options.Options) error {
 			if err != nil {
 				return fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = opts.RemoteRepoClonePath
+			cloneOpts.Path = opts.RemoteRepoDir
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),
@@ -912,7 +912,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 			if err != nil {
 				return nil, fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = opts.RemoteRepoClonePath
+			cloneOpts.Path = opts.RemoteRepoDir
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -138,7 +138,7 @@ func Run(ctx context.Context, opts options.Options) error {
 			if err != nil {
 				return fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = constants.MagicRemoteRepoDir
+			cloneOpts.Path = opts.RemoteRepoClonePath
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),
@@ -912,7 +912,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 			if err != nil {
 				return nil, fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = constants.MagicRemoteRepoDir
+			cloneOpts.Path = opts.RemoteRepoClonePath
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),

--- a/options/options.go
+++ b/options/options.go
@@ -158,9 +158,9 @@ type Options struct {
 	// working on the same repository.
 	RemoteRepoBuildMode bool
 
-	// RemoteRepoClonePath is the destination path for the cloned repo when
-	// using remote repo build mode.
-	RemoteRepoClonePath string
+	// RemoteRepoDir is the destination directory for the cloned repo when using
+	// remote repo build mode.
+	RemoteRepoDir string
 
 	// BinaryPath is the path to the local envbuilder binary when
 	// attempting to probe the build cache. This is only relevant when
@@ -456,12 +456,12 @@ func (o *Options) CLI() serpent.OptionSet {
 				"working on the same repository.",
 		},
 		{
-			Flag:        "remote-repo-clone-path",
-			Env:         WithEnvPrefix("REMOTE_REPO_CLONE_PATH"),
-			Value:       serpent.StringOf(&o.RemoteRepoClonePath),
+			Flag:        "remote-repo-dir",
+			Env:         WithEnvPrefix("REMOTE_REPO_DIR"),
+			Value:       serpent.StringOf(&o.RemoteRepoDir),
 			Default:     constants.MagicRemoteRepoDir,
 			Hidden:      true,
-			Description: "Specify the destination path for the cloned repo when using remote repo build mode.",
+			Description: "Specify the destination directory for the cloned repo when using remote repo build mode.",
 		},
 		{
 			Flag:        "verbose",

--- a/options/options.go
+++ b/options/options.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/coder/envbuilder/constants"
 	"github.com/coder/envbuilder/log"
 	"github.com/coder/serpent"
 	"github.com/go-git/go-billy/v5"
@@ -156,6 +157,10 @@ type Options struct {
 	// used to improving cache utilization when multiple users are building
 	// working on the same repository.
 	RemoteRepoBuildMode bool
+
+	// RemoteRepoClonePath is the destination path for the cloned repo when
+	// using remote repo build mode.
+	RemoteRepoClonePath string
 
 	// BinaryPath is the path to the local envbuilder binary when
 	// attempting to probe the build cache. This is only relevant when
@@ -449,6 +454,14 @@ func (o *Options) CLI() serpent.OptionSet {
 				"to local files and they will not be reflected in the image. This can " +
 				"be used to improving cache utilization when multiple users are building " +
 				"working on the same repository.",
+		},
+		{
+			Flag:        "remote-repo-clone-path",
+			Env:         WithEnvPrefix("REMOTE_REPO_CLONE_PATH"),
+			Value:       serpent.StringOf(&o.RemoteRepoClonePath),
+			Default:     constants.MagicRemoteRepoDir,
+			Hidden:      true,
+			Description: "Specify the destination path for the cloned repo when using remote repo build mode.",
 		},
 		{
 			Flag:        "verbose",


### PR DESCRIPTION
Changing the clone path is necessary for the terraform provider, this PR adds a hidden option for it.