### PR TITLE
fixup! ci: fix version script and update release.yaml (#303)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
         env:
           ENVBUILDER_RELEASE: "t"
         run: |
-          echo "ENVBUILDER_VERSION=$(./scripts.version.sh)" >> $GITHUB_OUTPUT
+          echo "ENVBUILDER_VERSION=$(./scripts/version.sh)" >> $GITHUB_OUTPUT
 
       - name: Build and Push
         env:


### PR DESCRIPTION
Fixes a typo in our version.sh invocation. This has already been applied to the release branch.