### PR TITLE
fix: prevent git progress writer race reading stageNumber

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -116,7 +116,8 @@ func Run(ctx context.Context, opts options.Options) error {
 			newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 		)
 
-		w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNumber, line) })
+		stageNum := stageNumber
+		w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNum, line) })
 		defer w.Close()
 		cloneOpts.Progress = w
 
@@ -132,6 +133,8 @@ func Run(ctx context.Context, opts options.Options) error {
 			opts.Logger(log.LevelError, "Falling back to the default image...")
 		}
 
+		_ = w.Close()
+
 		// Always clone the repo in remote repo build mode into a location that
 		// we control that isn't affected by the users changes.
 		if opts.RemoteRepoBuildMode {
@@ -146,7 +149,8 @@ func Run(ctx context.Context, opts options.Options) error {
 				newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 			)
 
-			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNumber, line) })
+			stageNum := stageNumber
+			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNum, line) })
 			defer w.Close()
 			cloneOpts.Progress = w
 
@@ -158,6 +162,8 @@ func Run(ctx context.Context, opts options.Options) error {
 				opts.Logger(log.LevelError, "Failed to clone repository for remote repo mode: %s", fallbackErr.Error())
 				opts.Logger(log.LevelError, "Falling back to the default image...")
 			}
+
+			_ = w.Close()
 		}
 	}
 
@@ -893,7 +899,8 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 			)
 
-			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNumber, line) })
+			stageNum := stageNumber
+			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNum, line) })
 			defer w.Close()
 			cloneOpts.Progress = w
 
@@ -908,6 +915,8 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				opts.Logger(log.LevelError, "Failed to clone repository: %s", fallbackErr.Error())
 				opts.Logger(log.LevelError, "Falling back to the default image...")
 			}
+
+			_ = w.Close()
 		} else {
 			cloneOpts, err := git.CloneOptionsFromOptions(opts)
 			if err != nil {
@@ -920,7 +929,8 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 			)
 
-			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNumber, line) })
+			stageNum := stageNumber
+			w := git.ProgressWriter(func(line string) { opts.Logger(log.LevelInfo, "#%d: %s", stageNum, line) })
 			defer w.Close()
 			cloneOpts.Progress = w
 
@@ -932,6 +942,8 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				opts.Logger(log.LevelError, "Failed to clone repository for remote repo mode: %s", fallbackErr.Error())
 				opts.Logger(log.LevelError, "Falling back to the default image...")
 			}
+
+			_ = w.Close()
 		}
 	}
 


### PR DESCRIPTION
Since the progress writer runs in a goroutine, it can call the write
function after the git operation has exited and while the next stage is
starting, resulting in a race. This fixes the race by using a second
variable and closing the writer early.

An alternative fix is to rewrite the progress writer to be synchronous.
