### PR TITLE
fix(envbuilder): RunCacheProbe: remove references to constants.MagicDir

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -948,7 +948,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 	}
 
 	defaultBuildParams := func() (*devcontainer.Compiled, error) {
-		dockerfile := filepath.Join(constants.MagicDir, "Dockerfile")
+		dockerfile := filepath.Join(buildTimeWorkspaceFolder, "Dockerfile")
 		file, err := opts.Filesystem.OpenFile(dockerfile, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return nil, err
@@ -970,7 +970,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 		return &devcontainer.Compiled{
 			DockerfilePath:    dockerfile,
 			DockerfileContent: content,
-			BuildContext:      constants.MagicDir,
+			BuildContext:      buildTimeWorkspaceFolder,
 		}, nil
 	}
 
@@ -1010,7 +1010,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 					opts.Logger(log.LevelInfo, "No Dockerfile or image specified; falling back to the default image...")
 					fallbackDockerfile = defaultParams.DockerfilePath
 				}
-				buildParams, err = devContainer.Compile(opts.Filesystem, devcontainerDir, constants.MagicDir, fallbackDockerfile, opts.WorkspaceFolder, false, os.LookupEnv)
+				buildParams, err = devContainer.Compile(opts.Filesystem, devcontainerDir, buildTimeWorkspaceFolder, fallbackDockerfile, opts.WorkspaceFolder, false, os.LookupEnv)
 				if err != nil {
 					return nil, fmt.Errorf("compile devcontainer.json: %w", err)
 				}

--- a/envbuilder_internal_test.go
+++ b/envbuilder_internal_test.go
@@ -1,46 +1,14 @@
 package envbuilder
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/coder/envbuilder/options"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestRunCacheProbe(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name          string
-		files         map[string]string
-		mutateOptions func(*options.Options)
-		assertImage   func(v1.Image)
-		assertError   func(error)
-	}{} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if tc.assertError == nil && tc.assertImage == nil {
-				require.Failf(t, "%s: either assertError or assertImage must be defined", tc.name)
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			t.Cleanup(cancel)
-			var opts options.Options
-			img, err := RunCacheProbe(ctx, opts)
-			if tc.assertImage != nil {
-				tc.assertImage(img)
-			}
-			if tc.assertError != nil {
-				tc.assertError(err)
-			}
-		})
-	}
-}
 
 func TestFindDevcontainerJSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Relates to https://github.com/coder/envbuilder/issues/314

`RunCacheProbe` is likely to execute without root permissions (e.g. via Terraform provider).
Writing to `constants.MagicDir` will fail in this case due to lack of permission.
Instead, use `buildTimeWorkspaceFolder` to write a `Dockerfile` when compiling from a `devcontainer.json`.