### PR TITLE
chore: update kaniko fork to fix 32-bit ARM build failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,8 @@ jobs:
 
           ./scripts/build.sh \
             --arch=amd64 \
+            --arch=arm64 \
+            --arch=arm \
             --base=$BASE
 
       - name: Build and Push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,13 +99,14 @@ jobs:
       - name: Build
         if: github.event_name == 'pull_request'
         run: |
-          BASE=ghcr.io/coder/envbuilder-preview
+          ./scripts/build.sh \
+            --arch=amd64
 
           ./scripts/build.sh \
-            --arch=amd64 \
-            --arch=arm64 \
-            --arch=arm \
-            --base=$BASE
+            --arch=arm64
+
+          ./scripts/build.sh \
+            --arch=arm
 
       - name: Build and Push
         if: github.ref == 'refs/heads/main'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 // There are a few options we need added to Kaniko!
 // See: https://github.com/GoogleContainerTools/kaniko/compare/main...coder:kaniko:main
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240830092517-0668f96c8816
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca
 
 // Required to import codersdk due to gvisor dependency.
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20240702054557-aa558fbe5374

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352 h1:L/EjCuZxs5tOcqqCaASj/nu65TRYEFcTt8qRQfHZXX0=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352/go.mod h1:P1KoQSgnKEAG6Mnd3YlGzAophty+yKA9VV48LpfNRvo=
-github.com/coder/kaniko v0.0.0-20240830092517-0668f96c8816 h1:idB8jAnkYWkHYddbJ+WnGtM2wrhh3+JpjPwHcQ2lYhU=
-github.com/coder/kaniko v0.0.0-20240830092517-0668f96c8816/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
+github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca h1:PrcSWrllqipTrtet50a3VyAJEQmjziIZyhpy0bsC6o0=
+github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=


### PR DESCRIPTION
- Updates kaniko fork to include https://github.com/coder/kaniko/pull/27
- Updates CI to build for all platforms, which would have caught the failure earlier (see:  https://github.com/coder/envbuilder/actions/runs/10631748586)