### PR TITLE
fix: set DOCKER_CONFIG dynamically

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1475,7 +1475,7 @@ func initDockerConfigJSON(logf log.Func, magicDir magicdir.MagicDir, dockerConfi
 	if dockerConfigBase64 == "" {
 		return noop, nil
 	}
-	cfgPath := filepath.Join(magicDir.Path(), "config.json")
+	cfgPath := magicDir.Join("config.json")
 	decoded, err := base64.StdEncoding.DecodeString(dockerConfigBase64)
 	if err != nil {
 		return noop, fmt.Errorf("decode docker config: %w", err)
@@ -1498,8 +1498,9 @@ func initDockerConfigJSON(logf log.Func, magicDir magicdir.MagicDir, dockerConfi
 	}
 	logf(log.LevelInfo, "Wrote Docker config JSON to %s", cfgPath)
 	oldDockerConfig := os.Getenv("DOCKER_CONFIG")
-	os.Setenv("DOCKER_CONFIG", magicDir.String())
-	logf(log.LevelInfo, "Set DOCKER_CONFIG to %s", magicDir.String())
+	_ = os.Setenv("DOCKER_CONFIG", magicDir.Path())
+	newDockerConfig := os.Getenv("DOCKER_CONFIG")
+	logf(log.LevelInfo, "Set DOCKER_CONFIG to %s", newDockerConfig)
 	cleanup := func() error {
 		var cleanupErr error
 		cleanupOnce.Do(func() {

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1497,9 +1497,15 @@ func initDockerConfigJSON(logf log.Func, magicDir magicdir.MagicDir, dockerConfi
 		return noop, fmt.Errorf("write docker config: %w", err)
 	}
 	logf(log.LevelInfo, "Wrote Docker config JSON to %s", cfgPath)
+	oldDockerConfig := os.Getenv("DOCKER_CONFIG")
+	os.Setenv("DOCKER_CONFIG", magicDir.String())
+	logf(log.LevelInfo, "Set DOCKER_CONFIG to %s", magicDir.String())
 	cleanup := func() error {
 		var cleanupErr error
 		cleanupOnce.Do(func() {
+			// Restore the old DOCKER_CONFIG value.
+			os.Setenv("DOCKER_CONFIG", oldDockerConfig)
+			logf(log.LevelInfo, "Restored DOCKER_CONFIG to %s", oldDockerConfig)
 			// Remove the Docker config secret file!
 			if cleanupErr = os.Remove(cfgPath); err != nil {
 				if !errors.Is(err, fs.ErrNotExist) {

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,5 @@ ARG TARGETARCH
 COPY envbuilder-${TARGETARCH} /.envbuilder/bin/envbuilder
 
 ENV KANIKO_DIR /.envbuilder
-# Kaniko looks for the Docker config at $DOCKER_CONFIG/config.json
-ENV DOCKER_CONFIG /.envbuilder
 
 ENTRYPOINT ["/.envbuilder/bin/envbuilder"]


### PR DESCRIPTION
Relates to https://github.com/coder/terraform-provider-envbuilder/issues/43

We were not setting `DOCKER_CONFIG` correctly, and were instead relying on having it set for us in the image. This change dynamically sets `DOCKER_CONFIG` at runtime instead, and removes the definition in the Envbuilder image.