### PR TITLE
chore: remove remote-repo-dir option

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -148,7 +148,7 @@ func Run(ctx context.Context, opts options.Options) error {
 			if err != nil {
 				return fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = opts.RemoteRepoDir
+			cloneOpts.Path = magicDir.Join("repo")
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),
@@ -927,7 +927,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 			if err != nil {
 				return nil, fmt.Errorf("git clone options: %w", err)
 			}
-			cloneOpts.Path = opts.RemoteRepoDir
+			cloneOpts.Path = magicDir.Join("repo")
 
 			endStage := startStage("📦 Remote repo build mode enabled, cloning %s to %s for build context...",
 				newColor(color.FgCyan).Sprintf(opts.GitURL),

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -59,9 +59,6 @@ func (o *Options) SetDefaults() {
 	if o.WorkspaceFolder == "" {
 		o.WorkspaceFolder = DefaultWorkspaceFolder(o.GitURL)
 	}
-	if o.RemoteRepoDir == "" {
-		o.RemoteRepoDir = magicdir.Default.Join("repo")
-	}
 	if o.BinaryPath == "" {
 		o.BinaryPath = "/.envbuilder/bin/envbuilder"
 	}

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -85,7 +85,6 @@ func TestOptions_SetDefaults(t *testing.T) {
 		GitURL:          "",
 		WorkspaceFolder: options.EmptyWorkspaceDir,
 		MagicDirBase:    "/.envbuilder",
-		RemoteRepoDir:   "/.envbuilder/repo",
 		BinaryPath:      "/.envbuilder/bin/envbuilder",
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -157,10 +157,6 @@ type Options struct {
 	// working on the same repository.
 	RemoteRepoBuildMode bool
 
-	// RemoteRepoDir is the destination directory for the cloned repo when using
-	// remote repo build mode.
-	RemoteRepoDir string
-
 	// BinaryPath is the path to the local envbuilder binary when
 	// attempting to probe the build cache. This is only relevant when
 	// GetCachedImage is true.
@@ -458,14 +454,6 @@ func (o *Options) CLI() serpent.OptionSet {
 				"to local files and they will not be reflected in the image. This can " +
 				"be used to improving cache utilization when multiple users are building " +
 				"working on the same repository.",
-		},
-		{
-			Flag:  "remote-repo-dir",
-			Env:   WithEnvPrefix("REMOTE_REPO_DIR"),
-			Value: serpent.StringOf(&o.RemoteRepoDir),
-			// Default:     magicdir.Default.Join("repo"), // TODO: reinstate once legacy opts are removed.
-			Hidden:      true,
-			Description: "Specify the destination directory for the cloned repo when using remote repo build mode.",
 		},
 		{
 			Flag:        "verbose",


### PR DESCRIPTION
This option is no longer required since we can change magicdir.
