### PR TITLE
feat(git): log parsed gitURL and warn if local

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -126,7 +126,7 @@ func Run(ctx context.Context, opts options.Options) error {
 			return fmt.Errorf("git clone options: %w", err)
 		}
 
-		w := git.ProgressWriter(func(line string) { logStage(line) })
+		w := git.ProgressWriter(logStage)
 		defer w.Close()
 		cloneOpts.Progress = w
 
@@ -158,7 +158,7 @@ func Run(ctx context.Context, opts options.Options) error {
 				newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 			)
 
-			w := git.ProgressWriter(func(line string) { logStage(line) })
+			w := git.ProgressWriter(logStage)
 			defer w.Close()
 			cloneOpts.Progress = w
 
@@ -910,7 +910,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				return nil, fmt.Errorf("git clone options: %w", err)
 			}
 
-			w := git.ProgressWriter(func(line string) { logStage(line) })
+			w := git.ProgressWriter(logStage)
 			defer w.Close()
 			cloneOpts.Progress = w
 
@@ -939,7 +939,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 				newColor(color.FgCyan).Sprintf(cloneOpts.Path),
 			)
 
-			w := git.ProgressWriter(func(line string) { logStage(line) })
+			w := git.ProgressWriter(logStage)
 			defer w.Close()
 			cloneOpts.Progress = w
 

--- a/git/git.go
+++ b/git/git.go
@@ -206,6 +206,8 @@ func LogHostKeyCallback(logger log.Func) gossh.HostKeyCallback {
 // | https?://host.tld/repo  | Not Set      | Set          | HTTP Basic  |
 // | https?://host.tld/repo  | Set          | Not Set      | HTTP Basic  |
 // | https?://host.tld/repo  | Set          | Set          | HTTP Basic  |
+// | file://path/to/repo     | -            | -            | None        |
+// | path/to/repo            | -            | -            | None        |
 // | All other formats       | -            | -            | SSH         |
 //
 // For SSH authentication, the default username is "git" but will honour
@@ -225,6 +227,7 @@ func SetupRepoAuth(options *options.Options) transport.AuthMethod {
 	parsedURL, err := giturls.Parse(options.GitURL)
 	if err != nil {
 		options.Logger(log.LevelError, "#1: ❌ Failed to parse Git URL: %s", err.Error())
+		return nil
 	}
 
 	if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {

--- a/git/git.go
+++ b/git/git.go
@@ -12,7 +12,6 @@ import (
 	"github.com/coder/envbuilder/options"
 
 	giturls "github.com/chainguard-dev/git-urls"
-	"github.com/coder/envbuilder/log"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -40,7 +39,6 @@ type CloneRepoOptions struct {
 	Depth        int
 	CABundle     []byte
 	ProxyOptions transport.ProxyOptions
-	Logf         log.Func
 }
 
 // CloneRepo will clone the repository at the given URL into the given path.
@@ -48,12 +46,12 @@ type CloneRepoOptions struct {
 // be cloned again.
 //
 // The bool returned states whether the repository was cloned or not.
-func CloneRepo(ctx context.Context, opts CloneRepoOptions) (bool, error) {
+func CloneRepo(ctx context.Context, logf func(string, ...any), opts CloneRepoOptions) (bool, error) {
 	parsed, err := giturls.Parse(opts.RepoURL)
 	if err != nil {
 		return false, fmt.Errorf("parse url %q: %w", opts.RepoURL, err)
 	}
-	opts.Logf(log.LevelInfo, "#1: Parsed Git URL as %q", parsed.Redacted())
+	logf("Parsed Git URL as %q", parsed.Redacted())
 	if parsed.Hostname() == "dev.azure.com" {
 		// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
 		// which are not fully implemented and by default are included in
@@ -75,7 +73,7 @@ func CloneRepo(ctx context.Context, opts CloneRepoOptions) (bool, error) {
 		transport.UnsupportedCapabilities = []capability.Capability{
 			capability.ThinPack,
 		}
-		opts.Logf(log.LevelInfo, "#1: Workaround for Azure DevOps: marking thin-pack as unsupported")
+		logf("Workaround for Azure DevOps: marking thin-pack as unsupported")
 	}
 
 	err = opts.Storage.MkdirAll(opts.Path, 0o755)
@@ -134,7 +132,7 @@ func CloneRepo(ctx context.Context, opts CloneRepoOptions) (bool, error) {
 // clone will not be performed.
 //
 // The bool returned states whether the repository was cloned or not.
-func ShallowCloneRepo(ctx context.Context, opts CloneRepoOptions) error {
+func ShallowCloneRepo(ctx context.Context, logf func(string, ...any), opts CloneRepoOptions) error {
 	opts.Depth = 1
 	opts.SingleBranch = true
 
@@ -153,7 +151,7 @@ func ShallowCloneRepo(ctx context.Context, opts CloneRepoOptions) error {
 		}
 	}
 
-	cloned, err := CloneRepo(ctx, opts)
+	cloned, err := CloneRepo(ctx, logf, opts)
 	if err != nil {
 		return err
 	}
@@ -185,14 +183,14 @@ func ReadPrivateKey(path string) (gossh.Signer, error) {
 
 // LogHostKeyCallback is a HostKeyCallback that just logs host keys
 // and does nothing else.
-func LogHostKeyCallback(logger log.Func) gossh.HostKeyCallback {
+func LogHostKeyCallback(logger func(string, ...any)) gossh.HostKeyCallback {
 	return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
 		var sb strings.Builder
 		_ = knownhosts.WriteKnownHost(&sb, hostname, remote, key)
 		// skeema/knownhosts uses a fake public key to determine the host key
 		// algorithms. Ignore this one.
 		if s := sb.String(); !strings.Contains(s, "fake-public-key ZmFrZSBwdWJsaWMga2V5") {
-			logger(log.LevelInfo, "#1: 🔑 Got host key: %s", strings.TrimSpace(s))
+			logger("🔑 Got host key: %s", strings.TrimSpace(s))
 		}
 		return nil
 	}
@@ -219,27 +217,27 @@ func LogHostKeyCallback(logger log.Func) gossh.HostKeyCallback {
 // If SSH_KNOWN_HOSTS is not set, the SSH auth method will be configured
 // to accept and log all host keys. Otherwise, host key checking will be
 // performed as usual.
-func SetupRepoAuth(options *options.Options) transport.AuthMethod {
+func SetupRepoAuth(logf func(string, ...any), options *options.Options) transport.AuthMethod {
 	if options.GitURL == "" {
-		options.Logger(log.LevelInfo, "#1: ❔ No Git URL supplied!")
+		logf("❔ No Git URL supplied!")
 		return nil
 	}
 	parsedURL, err := giturls.Parse(options.GitURL)
 	if err != nil {
-		options.Logger(log.LevelError, "#1: ❌ Failed to parse Git URL: %s", err.Error())
+		logf("❌ Failed to parse Git URL: %s", err.Error())
 		return nil
 	}
 
 	if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {
 		// Special case: no auth
 		if options.GitUsername == "" && options.GitPassword == "" {
-			options.Logger(log.LevelInfo, "#1: 👤 Using no authentication!")
+			logf("👤 Using no authentication!")
 			return nil
 		}
 		// Basic Auth
 		// NOTE: we previously inserted the credentials into the repo URL.
 		// This was removed in https://github.com/coder/envbuilder/pull/141
-		options.Logger(log.LevelInfo, "#1: 🔒 Using HTTP basic authentication!")
+		logf("🔒 Using HTTP basic authentication!")
 		return &githttp.BasicAuth{
 			Username: options.GitUsername,
 			Password: options.GitPassword,
@@ -251,7 +249,7 @@ func SetupRepoAuth(options *options.Options) transport.AuthMethod {
 		// filesystem clones. However, it's more likely than not that the
 		// `git` command is not present in the container image. Log a warning
 		// but continue. Also, no auth.
-		options.Logger(log.LevelWarn, "#1: 🚧 Using local filesystem clone! This requires the git executable to be present!")
+		logf("🚧 Using local filesystem clone! This requires the git executable to be present!")
 		return nil
 	}
 
@@ -262,30 +260,30 @@ func SetupRepoAuth(options *options.Options) transport.AuthMethod {
 	}
 
 	// Assume SSH auth for all other formats.
-	options.Logger(log.LevelInfo, "#1: 🔑 Using SSH authentication!")
+	logf("🔑 Using SSH authentication!")
 
 	var signer ssh.Signer
 	if options.GitSSHPrivateKeyPath != "" {
 		s, err := ReadPrivateKey(options.GitSSHPrivateKeyPath)
 		if err != nil {
-			options.Logger(log.LevelError, "#1: ❌ Failed to read private key from %s: %s", options.GitSSHPrivateKeyPath, err.Error())
+			logf("❌ Failed to read private key from %s: %s", options.GitSSHPrivateKeyPath, err.Error())
 		} else {
-			options.Logger(log.LevelInfo, "#1: 🔑 Using %s key!", s.PublicKey().Type())
+			logf("🔑 Using %s key!", s.PublicKey().Type())
 			signer = s
 		}
 	}
 
 	// If no SSH key set, fall back to agent auth.
 	if signer == nil {
-		options.Logger(log.LevelError, "#1: 🔑 No SSH key found, falling back to agent!")
+		logf("🔑 No SSH key found, falling back to agent!")
 		auth, err := gitssh.NewSSHAgentAuth(options.GitUsername)
 		if err != nil {
-			options.Logger(log.LevelError, "#1: ❌ Failed to connect to SSH agent: %s", err.Error())
+			logf("❌ Failed to connect to SSH agent: " + err.Error())
 			return nil // nothing else we can do
 		}
 		if os.Getenv("SSH_KNOWN_HOSTS") == "" {
-			options.Logger(log.LevelWarn, "#1: 🔓 SSH_KNOWN_HOSTS not set, accepting all host keys!")
-			auth.HostKeyCallback = LogHostKeyCallback(options.Logger)
+			logf("🔓 SSH_KNOWN_HOSTS not set, accepting all host keys!")
+			auth.HostKeyCallback = LogHostKeyCallback(logf)
 		}
 		return auth
 	}
@@ -303,35 +301,34 @@ func SetupRepoAuth(options *options.Options) transport.AuthMethod {
 
 	// Duplicated code due to Go's type system.
 	if os.Getenv("SSH_KNOWN_HOSTS") == "" {
-		options.Logger(log.LevelWarn, "#1: 🔓 SSH_KNOWN_HOSTS not set, accepting all host keys!")
-		auth.HostKeyCallback = LogHostKeyCallback(options.Logger)
+		logf("🔓 SSH_KNOWN_HOSTS not set, accepting all host keys!")
+		auth.HostKeyCallback = LogHostKeyCallback(logf)
 	}
 	return auth
 }
 
-func CloneOptionsFromOptions(options options.Options) (CloneRepoOptions, error) {
+func CloneOptionsFromOptions(logf func(string, ...any), options options.Options) (CloneRepoOptions, error) {
 	caBundle, err := options.CABundle()
 	if err != nil {
 		return CloneRepoOptions{}, err
 	}
 
 	cloneOpts := CloneRepoOptions{
+		RepoURL:      options.GitURL,
 		Path:         options.WorkspaceFolder,
 		Storage:      options.Filesystem,
 		Insecure:     options.Insecure,
 		SingleBranch: options.GitCloneSingleBranch,
 		Depth:        int(options.GitCloneDepth),
 		CABundle:     caBundle,
-		Logf:         options.Logger,
 	}
 
-	cloneOpts.RepoAuth = SetupRepoAuth(&options)
+	cloneOpts.RepoAuth = SetupRepoAuth(logf, &options)
 	if options.GitHTTPProxyURL != "" {
 		cloneOpts.ProxyOptions = transport.ProxyOptions{
 			URL: options.GitHTTPProxyURL,
 		}
 	}
-	cloneOpts.RepoURL = options.GitURL
 
 	return cloneOpts, nil
 }

--- a/git/git.go
+++ b/git/git.go
@@ -349,7 +349,7 @@ func (w *progressWriter) Close() error {
 	return err2
 }
 
-func ProgressWriter(write func(line string)) io.WriteCloser {
+func ProgressWriter(write func(line string, args ...any)) io.WriteCloser {
 	reader, writer := io.Pipe()
 	done := make(chan struct{})
 	go func() {
@@ -365,6 +365,8 @@ func ProgressWriter(write func(line string)) io.WriteCloser {
 				if line == "" {
 					continue
 				}
+				// Escape % signs so that they don't get interpreted as format specifiers
+				line = strings.Replace(line, "%", "%%", -1)
 				write(strings.TrimSpace(line))
 			}
 		}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -95,6 +95,7 @@ func TestCloneRepo(t *testing.T) {
 					Path:    "/",
 					RepoURL: srv.URL,
 					Storage: clientFS,
+					Logf:    testLog(t),
 				})
 				require.NoError(t, err)
 				require.False(t, cloned)
@@ -117,6 +118,7 @@ func TestCloneRepo(t *testing.T) {
 						Username: tc.username,
 						Password: tc.password,
 					},
+					Logf: testLog(t),
 				})
 				require.Equal(t, tc.expectClone, cloned)
 				if tc.expectError != "" {
@@ -150,6 +152,7 @@ func TestCloneRepo(t *testing.T) {
 					Path:    "/workspace",
 					RepoURL: authURL.String(),
 					Storage: clientFS,
+					Logf:    testLog(t),
 				})
 				require.Equal(t, tc.expectClone, cloned)
 				if tc.expectError != "" {
@@ -199,6 +202,7 @@ func TestShallowCloneRepo(t *testing.T) {
 				Username: "test",
 				Password: "test",
 			},
+			Logf: testLog(t),
 		})
 		require.Error(t, err)
 	})
@@ -227,6 +231,7 @@ func TestShallowCloneRepo(t *testing.T) {
 				Username: "test",
 				Password: "test",
 			},
+			Logf: testLog(t),
 		})
 		require.NoError(t, err)
 		for _, path := range []string{"README.md", "foo", "baz"} {
@@ -264,6 +269,7 @@ func TestCloneRepoSSH(t *testing.T) {
 					HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 				},
 			},
+			Logf: testLog(t),
 		})
 		// TODO: ideally, we want to test the entire cloning flow.
 		// For now, this indicates successful ssh key auth.
@@ -296,6 +302,7 @@ func TestCloneRepoSSH(t *testing.T) {
 					HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 				},
 			},
+			Logf: testLog(t),
 		})
 		require.ErrorContains(t, err, "handshake failed")
 		require.False(t, cloned)
@@ -325,6 +332,7 @@ func TestCloneRepoSSH(t *testing.T) {
 					HostKeyCallback: gossh.FixedHostKey(randKeygen(t).PublicKey()),
 				},
 			},
+			Logf: testLog(t),
 		})
 		require.ErrorContains(t, err, "ssh: host key mismatch")
 		require.False(t, cloned)
@@ -452,6 +460,33 @@ func TestSetupRepoAuth(t *testing.T) {
 		}
 		auth := git.SetupRepoAuth(opts)
 		require.Nil(t, auth) // TODO: actually test SSH_AUTH_SOCK
+	})
+
+	t.Run("NoHostname/RepoOnly", func(t *testing.T) {
+		opts := &options.Options{
+			GitURL: "repo",
+			Logger: testLog(t),
+		}
+		auth := git.SetupRepoAuth(opts)
+		require.Nil(t, auth)
+	})
+
+	t.Run("NoHostname/Org/Repo", func(t *testing.T) {
+		opts := &options.Options{
+			GitURL: "org/repo",
+			Logger: testLog(t),
+		}
+		auth := git.SetupRepoAuth(opts)
+		require.Nil(t, auth)
+	})
+
+	t.Run("NoHostname/AbsolutePathish", func(t *testing.T) {
+		opts := &options.Options{
+			GitURL: "/org/repo",
+			Logger: testLog(t),
+		}
+		auth := git.SetupRepoAuth(opts)
+		require.Nil(t, auth)
 	})
 }
 


### PR DESCRIPTION
Part of https://github.com/coder/envbuilder/issues/281

If we go about fetching changes from a remote repo, we're going to want to log some more information about what's going on.
I also took this opportunity to log some more information about the git URL we parse.
Specifically, if a user passes a git URL in the form of `OrgName/RepoName` our library for parsing git URLs will interpret that as a local URL (`file://`). 
`go-git` will fall back to the `git` executable in this case, which is likely to fail if `git` is not present. I'm choosing to log a warn but not block in case someone decides to make their own envbuilder image with `git` installed.