### PR TITLE
fix: use openfile to explicitly set magic image perms

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1596,7 +1596,7 @@ func copyFile(fs billy.Filesystem, src, dst string, mode fs.FileMode) error {
 }
 
 func writeMagicImageFile(fs billy.Filesystem, path string, v any) error {
-	file, err := fs.Create(path)
+	file, err := fs.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("create magic image file: %w", err)
 	}


### PR DESCRIPTION
This should fix an issue in our provider tests where build was producing an `rw-r--r--` and cache probing an `-rw-rw-r--` image file, resulting in a cache miss.