### PR TITLE
fix: quote output of init command and args to prevent multiline log

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -104,7 +104,7 @@ func Run(ctx context.Context, opts options.Options, preExec ...func()) error {
 		return fmt.Errorf("set uid: %w", err)
 	}
 
-	opts.Logger(log.LevelInfo, "=== Running the init command %s %+v as the %q user...", opts.InitCommand, args.InitArgs, args.UserInfo.user.Username)
+	opts.Logger(log.LevelInfo, "=== Running init command as user %q: %q", args.UserInfo.user.Username, append([]string{opts.InitCommand}, args.InitArgs...))
 	for _, fn := range preExec {
 		fn()
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -84,7 +84,7 @@ func TestLogs(t *testing.T) {
 			}
 			for _, log := range req.Logs {
 				t.Logf("got log: %+v", log)
-				if strings.Contains(log.Output, "Running the init command") {
+				if strings.Contains(log.Output, "Running init command") {
 					close(logsDone)
 					return
 				}
@@ -2294,7 +2294,7 @@ func runEnvbuilder(t *testing.T, opts runOpts) (string, error) {
 	logChan, errChan := streamContainerLogs(t, cli, ctr.ID)
 	go func() {
 		for log := range logChan {
-			if strings.HasPrefix(log, "=== Running the init command") {
+			if strings.HasPrefix(log, "=== Running init command") {
 				errChan <- nil
 				return
 			}


### PR DESCRIPTION
Before:

```
=== Running the init command /usr/bin/echo [abra
cadabra
] as the "coder" user...
abra
cadabra
```

After:

```
=== Running init command as user "coder": ["/usr/bin/echo" "abra\ncadabra\n"]
abra
cadabra
```

Refs coder/coder#14882
