### PR TITLE
fix(scripts): always return the latest tag in version.sh

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -36,11 +36,11 @@ if [[ -z ${tag_list} ]]; then
 else
 	current_commit=$(git rev-parse HEAD)
 	# Try to find the last tag that contains the current commit
-	last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
+	last_tag=$(git tag --contains "$current_commit" --sort=-version:refname | head -n 1)
 	# If there is no tag that contains the current commit,
 	# get the latest tag sorted by semver.
 	if [[ -z "${last_tag}" ]]; then
-		last_tag=$(git tag --sort=version:refname | tail -n 1)
+		last_tag=$(git tag --sort=-version:refname | head -n 1)
 	fi
 fi
 


### PR DESCRIPTION
The `version.sh` script was prioritizing the first instead of last tag, which broke the v1.0.1 re-tag of v1.0.0.