### PR TITLE
fix: extract folder correctly from repo URLs with trailing slash

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -844,15 +844,17 @@ func TestContainerEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	output := execContainer(t, ctr, "cat /env")
-	require.Contains(t, strings.TrimSpace(output),
-		`DEVCONTAINER=true
+	want := `DEVCONTAINER=true
 DEVCONTAINER_CONFIG=/workspaces/empty/.devcontainer/devcontainer.json
 ENVBUILDER=true
 FROM_CONTAINER_ENV=bar
 FROM_DOCKERFILE=foo
 FROM_REMOTE_ENV=baz
 PATH=/usr/local/bin:/bin:/go/bin:/opt
-REMOTE_BAR=bar`)
+REMOTE_BAR=bar`
+	if diff := cmp.Diff(want, strings.TrimSpace(output)); diff != "" {
+		require.Failf(t, "env mismatch", "diff (-want +got):\n%s", diff)
+	}
 }
 
 func TestUnsetOptionsEnv(t *testing.T) {

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/go-git/go-billy/v5/osfs"
@@ -25,12 +26,14 @@ func DefaultWorkspaceFolder(repoURL string) string {
 	if err != nil {
 		return EmptyWorkspaceDir
 	}
-	name := strings.Split(parsed.Path, "/")
-	hasOwnerAndRepo := len(name) >= 2
-	if !hasOwnerAndRepo {
+	repo := path.Base(parsed.Path)
+	// Giturls parsing never actually fails since ParseLocal never
+	// errors and places the entire URL in the Path field. This check
+	// ensures it's at least a Unix path containing forwardslash.
+	if repo == repoURL || repo == "" {
 		return EmptyWorkspaceDir
 	}
-	repo := strings.TrimSuffix(name[len(name)-1], ".git")
+	repo = strings.TrimSuffix(repo, ".git")
 	return fmt.Sprintf("/workspaces/%s", repo)
 }
 

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -30,7 +30,7 @@ func DefaultWorkspaceFolder(repoURL string) string {
 	// Giturls parsing never actually fails since ParseLocal never
 	// errors and places the entire URL in the Path field. This check
 	// ensures it's at least a Unix path containing forwardslash.
-	if repo == repoURL || repo == "." || repo == "" {
+	if repo == repoURL || repo == "/" || repo == "." || repo == "" {
 		return EmptyWorkspaceDir
 	}
 	repo = strings.TrimSuffix(repo, ".git")

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -30,7 +30,7 @@ func DefaultWorkspaceFolder(repoURL string) string {
 	// Giturls parsing never actually fails since ParseLocal never
 	// errors and places the entire URL in the Path field. This check
 	// ensures it's at least a Unix path containing forwardslash.
-	if repo == repoURL || repo == "" {
+	if repo == repoURL || repo == "." || repo == "" {
 		return EmptyWorkspaceDir
 	}
 	repo = strings.TrimSuffix(repo, ".git")

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -36,11 +36,6 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 			expected: "/workspaces/envbuilder",
 		},
 		{
-			name:     "fragment",
-			gitURL:   "https://github.com/coder/envbuilder.git#feature-branch",
-			expected: "/workspaces/envbuilder",
-		},
-		{
 			name:     "trailing",
 			gitURL:   "https://github.com/coder/envbuilder.git/",
 			expected: "/workspaces/envbuilder",
@@ -51,19 +46,34 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 			expected: "/workspaces/envbuilder",
 		},
 		{
+			name:     "no .git",
+			gitURL:   "https://github.com/coder/envbuilder",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "trailing no .git",
+			gitURL:   "https://github.com/coder/envbuilder/",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "fragment",
+			gitURL:   "https://github.com/coder/envbuilder.git#feature-branch",
+			expected: "/workspaces/envbuilder",
+		},
+		{
 			name:     "fragment-trailing",
 			gitURL:   "https://github.com/coder/envbuilder.git/#refs/heads/feature-branch",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "fragment-trailing no .git",
+			gitURL:   "https://github.com/coder/envbuilder/#refs/heads/feature-branch",
 			expected: "/workspaces/envbuilder",
 		},
 		{
 			name:     "space",
 			gitURL:   "https://github.com/coder/env%20builder.git",
 			expected: "/workspaces/env builder",
-		},
-		{
-			name:     "no .git",
-			gitURL:   "https://github.com/coder/envbuilder",
-			expected: "/workspaces/envbuilder",
 		},
 		{
 			name:     "Unix path",

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -114,6 +114,10 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 			name:       "Unix root",
 			invalidURL: "/",
 		},
+		{
+			name:       "Git URL with no path",
+			invalidURL: "http://127.0.0.1:41073",
+		},
 	}
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -115,6 +115,10 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 			invalidURL: "/",
 		},
 		{
+			name:       "Path consists entirely of slash",
+			invalidURL: "//",
+		},
+		{
 			name:       "Git URL with no path",
 			invalidURL: "http://127.0.0.1:41073",
 		},

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -41,6 +41,41 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 			expected: "/workspaces/envbuilder",
 		},
 		{
+			name:     "trailing",
+			gitURL:   "https://github.com/coder/envbuilder.git/",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "trailing-x2",
+			gitURL:   "https://github.com/coder/envbuilder.git//",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "fragment-trailing",
+			gitURL:   "https://github.com/coder/envbuilder.git/#refs/heads/feature-branch",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "space",
+			gitURL:   "https://github.com/coder/env%20builder.git",
+			expected: "/workspaces/env builder",
+		},
+		{
+			name:     "no .git",
+			gitURL:   "https://github.com/coder/envbuilder",
+			expected: "/workspaces/envbuilder",
+		},
+		{
+			name:     "Unix path",
+			gitURL:   "/repo",
+			expected: "/workspaces/repo",
+		},
+		{
+			name:     "Unix subpath",
+			gitURL:   "/path/to/repo",
+			expected: "/workspaces/repo",
+		},
+		{
 			name:     "empty",
 			gitURL:   "",
 			expected: options.EmptyWorkspaceDir,
@@ -64,6 +99,10 @@ func TestDefaultWorkspaceFolder(t *testing.T) {
 		{
 			name:       "website URL",
 			invalidURL: "www.google.com",
+		},
+		{
+			name:       "Unix root",
+			invalidURL: "/",
 		},
 	}
 	for _, tt := range invalidTests {


### PR DESCRIPTION
Closes #380
Closes coder/customers#690
