### PR TITLE
fix(envbuilder.go)!: rename MagicDirBase CLI option

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -120,7 +120,7 @@ func Run(ctx context.Context, opts options.Options, preExec ...func()) error {
 func run(ctx context.Context, opts options.Options, execArgs *execArgsInfo) error {
 	defer options.UnsetEnv()
 
-	workingDir := workingdir.At(opts.MagicDirBase)
+	workingDir := workingdir.At(opts.WorkingDirBase)
 
 	stageNumber := 0
 	startStage := func(format string, args ...any) func(format string, args ...any) {
@@ -962,7 +962,7 @@ func RunCacheProbe(ctx context.Context, opts options.Options) (v1.Image, error) 
 		return nil, fmt.Errorf("--cache-repo must be set when using --get-cached-image")
 	}
 
-	workingDir := workingdir.At(opts.MagicDirBase)
+	workingDir := workingdir.At(opts.WorkingDirBase)
 
 	stageNumber := 0
 	startStage := func(format string, args ...any) func(format string, args ...any) {

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -65,7 +65,7 @@ func (o *Options) SetDefaults() {
 	if o.BinaryPath == "" {
 		o.BinaryPath = "/.envbuilder/bin/envbuilder"
 	}
-	if o.MagicDirBase == "" {
-		o.MagicDirBase = workingdir.Default.Path()
+	if o.WorkingDirBase == "" {
+		o.WorkingDirBase = workingdir.Default.Path()
 	}
 }

--- a/options/defaults_test.go
+++ b/options/defaults_test.go
@@ -141,7 +141,7 @@ func TestOptions_SetDefaults(t *testing.T) {
 		Filesystem:      chmodfs.New(osfs.New("/")),
 		GitURL:          "",
 		WorkspaceFolder: options.EmptyWorkspaceDir,
-		MagicDirBase:    "/.envbuilder",
+		WorkingDirBase:  "/.envbuilder",
 		BinaryPath:      "/.envbuilder/bin/envbuilder",
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -162,10 +162,10 @@ type Options struct {
 	// GetCachedImage is true.
 	BinaryPath string
 
-	// MagicDirBase is the path to the directory where all envbuilder files should be
+	// WorkingDirBase is the path to the directory where all envbuilder files should be
 	// stored. By default, this is set to `/.envbuilder`. This is intentionally
 	// excluded from the CLI options.
-	MagicDirBase string
+	WorkingDirBase string
 }
 
 const envPrefix = "ENVBUILDER_"


### PR DESCRIPTION
This PR is a breaking change!
It renames a publicly accessible CLI option referenced in #184.
It should not be merged into release/1.0 as this would break at least the terraform provider that relies on this option.

This commit may be cherry-picked into release/2.0 when that branch is created.

This PR closes #184.