### PR TITLE
feat: add env var for ssh private key

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -181,6 +182,22 @@ func ReadPrivateKey(path string) (gossh.Signer, error) {
 	return k, nil
 }
 
+// DecodeBase64PrivateKey attempts to decode a base64 encoded private
+// key and returns an ssh.Signer
+func DecodeBase64PrivateKey(key string) (gossh.Signer, error) {
+	bs, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key: %w", err)
+	}
+
+	k, err := gossh.ParsePrivateKey(bs)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+
+	return k, nil
+}
+
 // LogHostKeyCallback is a HostKeyCallback that just logs host keys
 // and does nothing else.
 func LogHostKeyCallback(logger func(string, ...any)) gossh.HostKeyCallback {
@@ -267,6 +284,17 @@ func SetupRepoAuth(logf func(string, ...any), options *options.Options) transpor
 		s, err := ReadPrivateKey(options.GitSSHPrivateKeyPath)
 		if err != nil {
 			logf("❌ Failed to read private key from %s: %s", options.GitSSHPrivateKeyPath, err.Error())
+		} else {
+			logf("🔑 Using %s key!", s.PublicKey().Type())
+			signer = s
+		}
+	}
+
+	// If no path was provided, fall back to the environment variable
+	if options.GitSSHPrivateKeyBase64 != "" {
+		s, err := DecodeBase64PrivateKey(options.GitSSHPrivateKeyBase64)
+		if err != nil {
+			logf("❌ Failed to decode base 64 private key : %s", err.Error())
 		} else {
 			logf("🔑 Using %s key!", s.PublicKey().Type())
 			signer = s

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -3,6 +3,7 @@ package git_test
 import (
 	"context"
 	"crypto/ed25519"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -433,6 +434,22 @@ func TestSetupRepoAuth(t *testing.T) {
 		require.Equal(t, actualSigner, pk.Signer)
 	})
 
+	t.Run("SSH/Base64PrivateKey", func(t *testing.T) {
+		opts := &options.Options{
+			GitURL:                 "ssh://git@host.tld:repo/path",
+			GitSSHPrivateKeyBase64: base64EncodeTestPrivateKey(),
+		}
+		auth := git.SetupRepoAuth(t.Logf, opts)
+
+		pk, ok := auth.(*gitssh.PublicKeys)
+		require.True(t, ok)
+		require.NotNil(t, pk.Signer)
+
+		actualSigner, err := gossh.ParsePrivateKey([]byte(testKey))
+		require.NoError(t, err)
+		require.Equal(t, actualSigner, pk.Signer)
+	})
+
 	t.Run("SSH/NoAuthMethods", func(t *testing.T) {
 		opts := &options.Options{
 			GitURL: "ssh://git@host.tld:repo/path",
@@ -501,4 +518,8 @@ func writeTestPrivateKey(t *testing.T) string {
 	kPath := filepath.Join(tmpDir, "test.key")
 	require.NoError(t, os.WriteFile(kPath, []byte(testKey), 0o600))
 	return kPath
+}
+
+func base64EncodeTestPrivateKey() string {
+	return base64.StdEncoding.EncodeToString([]byte(testKey))
 }

--- a/options/options.go
+++ b/options/options.go
@@ -108,6 +108,9 @@ type Options struct {
 	// GitSSHPrivateKeyPath is the path to an SSH private key to be used for
 	// Git authentication.
 	GitSSHPrivateKeyPath string
+	// GitSSHPrivateKeyBase64 is the content of an SSH private key to be used
+	// for Git authentication.
+	GitSSHPrivateKeyBase64 string
 	// GitHTTPProxyURL is the URL for the HTTP proxy. This is optional.
 	GitHTTPProxyURL string
 	// WorkspaceFolder is the path to the workspace folder that will be built.
@@ -362,6 +365,12 @@ func (o *Options) CLI() serpent.OptionSet {
 			Env:         WithEnvPrefix("GIT_SSH_PRIVATE_KEY_PATH"),
 			Value:       serpent.StringOf(&o.GitSSHPrivateKeyPath),
 			Description: "Path to an SSH private key to be used for Git authentication.",
+		},
+		{
+			Flag:        "git-ssh-private-key-base64",
+			Env:         WithEnvPrefix("GIT_SSH_PRIVATE_KEY_BASE64"),
+			Value:       serpent.StringOf(&o.GitSSHPrivateKeyBase64),
+			Description: "SSH private key to be used for Git authentication.",
 		},
 		{
 			Flag:        "git-http-proxy-url",

--- a/options/testdata/options.golden
+++ b/options/testdata/options.golden
@@ -94,6 +94,9 @@ OPTIONS:
       --git-password string, $ENVBUILDER_GIT_PASSWORD
           The password to use for Git authentication. This is optional.
 
+      --git-ssh-private-key-base64 string, $ENVBUILDER_GIT_SSH_PRIVATE_KEY_BASE64
+          SSH private key to be used for Git authentication.
+
       --git-ssh-private-key-path string, $ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH
           Path to an SSH private key to be used for Git authentication.
 


### PR DESCRIPTION
Closes https://github.com/coder/envbuilder/issues/333

Allow passing a base64 encoded ssh private key to `ENVBUILDER_GIT_SSH_PRIVATE_KEY_BASE64` and using this for git authentication.