### PR TITLE
fix: enable logging for setup script when not a tty

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -1,7 +1,6 @@
 package envbuilder
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -891,16 +890,8 @@ func run(ctx context.Context, opts options.Options, execArgs *execArgsInfo) erro
 			cmd.Stderr = os.Stderr
 			cmd.Stdin = os.Stdin
 		} else {
-			var buf bytes.Buffer
-			go func() {
-				scanner := bufio.NewScanner(&buf)
-				for scanner.Scan() {
-					opts.Logger(log.LevelInfo, "%s", scanner.Text())
-				}
-			}()
-
-			cmd.Stdout = &buf
-			cmd.Stderr = &buf
+			cmd.Stdout = newWriteLogger(opts.Logger, log.LevelInfo)
+			cmd.Stderr = newWriteLogger(opts.Logger, log.LevelError)
 		}
 		err = cmd.Run()
 		if err != nil {
@@ -1818,6 +1809,23 @@ func onceErrFunc(f func() error) func() error {
 		})
 		return err
 	}
+}
+
+type writeLogger struct {
+	logf  log.Func
+	level log.Level
+}
+
+func newWriteLogger(logf log.Func, level log.Level) io.Writer {
+	return writeLogger{logf: logf, level: level}
+}
+
+func (l writeLogger) Write(p []byte) (n int, err error) {
+	lines := bytes.Split(p, []byte("\n"))
+	for _, line := range lines {
+		l.logf(l.level, "%s", line)
+	}
+	return len(p), nil
 }
 
 // Allows quick testing of layer caching using a local directory!

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -126,6 +126,7 @@ func TestLogs(t *testing.T) {
 		envbuilderEnv("GIT_URL", srv.URL),
 		"CODER_AGENT_URL=" + logSrv.URL,
 		"CODER_AGENT_TOKEN=" + token,
+		"ENVBUILDER_SETUP_SCRIPT=/bin/sh -c 'echo MY${NO_MATCH_ENV}_SETUP_SCRIPT_OUT; echo MY${NO_MATCH_ENV}_SETUP_SCRIPT_ERR' 1>&2",
 		"ENVBUILDER_INIT_SCRIPT=env",
 	}})
 	require.NoError(t, err)
@@ -158,6 +159,8 @@ func TestLogs(t *testing.T) {
 	require.NoError(t, err)
 	logs := string(logBytes)
 	require.Contains(t, logs, "CODER_AGENT_SUBSYSTEM=envbuilder")
+	require.Contains(t, logs, "MY_SETUP_SCRIPT_OUT")
+	require.Contains(t, logs, "MY_SETUP_SCRIPT_ERR")
 }
 
 func TestInitScriptInitCommand(t *testing.T) {


### PR DESCRIPTION
Fixes #394
