### PR TITLE
fix(envbuilder): make init command more readable

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -47,6 +47,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
+	"github.com/mitchellh/go-wordwrap"
 	"github.com/sirupsen/logrus"
 	"github.com/tailscale/hujson"
 	"golang.org/x/xerrors"
@@ -104,7 +105,11 @@ func Run(ctx context.Context, opts options.Options, preExec ...func()) error {
 		return fmt.Errorf("set uid: %w", err)
 	}
 
-	opts.Logger(log.LevelInfo, "=== Running init command as user %q: %q", args.UserInfo.user.Username, append([]string{opts.InitCommand}, args.InitArgs...))
+	initCmd := append([]string{opts.InitCommand}, args.InitArgs...)
+	opts.Logger(log.LevelInfo, "=== Running init command as user %q", args.UserInfo.user.Username)
+	for _, line := range wordwrap.WrapString(initCmd, 76) {
+		opts.Logger(log.LevelInfo, "    "+line)
+	}
 	for _, fn := range preExec {
 		fn()
 	}

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -105,11 +105,10 @@ func Run(ctx context.Context, opts options.Options, preExec ...func()) error {
 		return fmt.Errorf("set uid: %w", err)
 	}
 
-	initCmd := append([]string{opts.InitCommand}, args.InitArgs...)
-	opts.Logger(log.LevelInfo, "=== Running init command as user %q", args.UserInfo.user.Username)
-	for _, line := range wordwrap.WrapString(initCmd, 76) {
-		opts.Logger(log.LevelInfo, "    "+line)
-	}
+	initCmd := strings.Join(append([]string{opts.InitCommand}, args.InitArgs...), " ")
+	opts.Logger(log.LevelInfo, "=== Running init command as user %q:", args.UserInfo.user.Username)
+	opts.Logger(log.LevelInfo, wordwrap.WrapString(initCmd, 80))
+	opts.Logger(log.LevelInfo, "===")
 	for _, fn := range preExec {
 		fn()
 	}


### PR DESCRIPTION
Makes output of long init scripts _much_ more readable, but potentially much more verbose.
I'm open to making it a `log.Debug` instead.

Before:

```
$ docker run -it --rm -v $PWD:/workspaces/empty --net=host -e ENVBUILDER_CACHE_REPO=localhost:5000/cache -e ENVBUILDER_INIT_COMMAND=/usr/bin/bash -e ENVBUILDER_INIT_SCRIPT="$(cat scripts/build.sh)"  ghcr.io/coder/envbuilder:latest
envbuilder v1.0.5+dc6aa54 - Build development environments from repositories in a container
[...]
=== Running init command as user "root": ["/usr/bin/bash" "-c" "#!/usr/bin/env bash\n\ncd \"$(dirname \"${BASH_SOURCE[0]}\")\"\nset -exuo pipefail\n\narchs=()\npush=false\nbase=\"envbuilder\"\ntag=\"\"\n\nfor arg in \"$@\"; do\n  if [[ $arg == --arch=* ]]; then\n    arch=\"${arg#*=}\"\n    archs+=( \"$arch\" )\n  elif [[ $arg == --push ]]; then\n    push=true\n  elif [[ $arg == --base=* ]]; then\n    base=\"${arg#*=}\"\n  elif [[ $arg == --tag=* ]]; then\n    tag=\"${arg#*=}\"\n  else\n    echo \"Unknown argument: $arg\"\n    exit 1\n  fi\ndone\n\ncurrent=$(go env GOARCH)\nif [ ${#archs[@]} -eq 0 ]; then\n  echo \"No architectures specified. Defaulting to $current...\"\n  archs=( \"$current\" ) \nfi\n\nif [[ -z \"${tag}\"  ]]; then\n\ttag=$(./version.sh)\nfi\n\n# We have to use docker buildx to tag multiple images with\n# platforms tragically, so we have to create a builder.\nBUILDER_NAME=\"envbuilder\"\nBUILDER_EXISTS=$(docker buildx ls | grep $BUILDER_NAME || true)\n\n# If builder doesn't exist, create it\nif [ -z \"$BUILDER_EXISTS\" ]; then\n  echo \"Creating dockerx builder $BUILDER_NAME...\"\n  docker buildx create --use --platform=linux/arm64,linux/amd64,linux/arm/v7 --name $BUILDER_NAME\nelse\n  echo \"Builder $BUILDER_NAME already exists. Using it.\"\nfi\n\n# Ensure the builder is bootstrapped and ready to use\ndocker buildx inspect --bootstrap &> /dev/null\n\nldflags=(-X \"'github.com/coder/envbuilder/buildinfo.tag=$tag'\")\n\nfor arch in \"${archs[@]}\"; do\n  echo \"Building for $arch...\"\n  GOARCH=$arch CGO_ENABLED=0 go build -ldflags=\"${ldflags[*]}\" -o \"./envbuilder-${arch}\" ../cmd/envbuilder &\ndone\nwait\n\nargs=()\nfor arch in \"${archs[@]}\"; do\n  args+=( --platform \"linux/${arch}\" )\ndone\nif [ \"$push\" = true ]; then\n  args+=( --push )\nelse\n  args+=( --load )\nfi\n\n# coerce semver build tags into something docker won't complain about\ntag=\"${tag//\\+/-}\"\ndocker buildx build --builder $BUILDER_NAME \"${args[@]}\" -t \"${base}:${tag}\" -t \"${base}:latest\" -f Dockerfile .\n\n# Check if archs contains the current. If so, then output a message!\nif [[ -z \"${CI:-}\" ]] && [[ \" ${archs[*]} \" =~ ${current} ]]; then\n  docker tag \"${base}:${tag}\" envbuilder:latest\n  echo \"Tagged $current as ${base}:${tag} ${base}:latest!\"\nfi"]
+ archs=()
+ push=false
+ base=envbuilder
+ tag=
++ go env GOARCH
+ current=amd64
+ '[' 0 -eq 0 ']'
+ echo 'No architectures specified. Defaulting to amd64...'
No architectures specified. Defaulting to amd64...
+ archs=("$current")
+ [[ -z '' ]]
++ ./version.sh
/usr/bin/bash: line 34: ./version.sh: No such file or directory
```

After:

```
$ docker run -it --rm -v $PWD:/workspaces/empty --net=host -e ENVBUILDER_CACHE_REPO=localhost:5000/cache -e ENVBUILDER_EXIT_ON_PUSH_FAILURE=1 -e ENVBUILD
ER_INIT_COMMAND=/usr/bin/bash -e ENVBUILDER_INIT_SCRIPT="$(cat scripts/build.sh)"  envbuilder:latest
envbuilder v1.0.5+dev-8635f11-dirty - Build development environments from repositories in a container
[...]
=== Running init command as user "root":
/usr/bin/bash -c #!/usr/bin/env bash

cd "$(dirname "${BASH_SOURCE[0]}")"
set -exuo pipefail

archs=()
push=false
base="envbuilder"
tag=""

for arg in "$@"; do
  if [[ $arg == --arch=* ]]; then
    arch="${arg#*=}"
    archs+=( "$arch" )
  elif [[ $arg == --push ]]; then
    push=true
  elif [[ $arg == --base=* ]]; then
    base="${arg#*=}"
  elif [[ $arg == --tag=* ]]; then
    tag="${arg#*=}"
  else
    echo "Unknown argument: $arg"
    exit 1
  fi
done

current=$(go env GOARCH)
if [ ${#archs[@]} -eq 0 ]; then
  echo "No architectures specified. Defaulting to $current..."
  archs=( "$current" ) 
fi

if [[ -z "${tag}"  ]]; then
        tag=$(./version.sh)
fi

# We have to use docker buildx to tag multiple images with
# platforms tragically, so we have to create a builder.
BUILDER_NAME="envbuilder"
BUILDER_EXISTS=$(docker buildx ls | grep $BUILDER_NAME || true)

# If builder doesn't exist, create it
if [ -z "$BUILDER_EXISTS" ]; then
  echo "Creating dockerx builder $BUILDER_NAME..."
  docker buildx create --use --platform=linux/arm64,linux/amd64,linux/arm/v7
--name $BUILDER_NAME
else
  echo "Builder $BUILDER_NAME already exists. Using it."
fi

# Ensure the builder is bootstrapped and ready to use
docker buildx inspect --bootstrap &> /dev/null

ldflags=(-X "'github.com/coder/envbuilder/buildinfo.tag=$tag'")

for arch in "${archs[@]}"; do
  echo "Building for $arch..."
  GOARCH=$arch CGO_ENABLED=0 go build -ldflags="${ldflags[*]}" -o
"./envbuilder-${arch}" ../cmd/envbuilder &
done
wait

args=()
for arch in "${archs[@]}"; do
  args+=( --platform "linux/${arch}" )
done
if [ "$push" = true ]; then
  args+=( --push )
else
  args+=( --load )
fi

# coerce semver build tags into something docker won't complain about
tag="${tag//\+/-}"
docker buildx build --builder $BUILDER_NAME "${args[@]}" -t "${base}:${tag}" -t
"${base}:latest" -f Dockerfile .

# Check if archs contains the current. If so, then output a message!
if [[ -z "${CI:-}" ]] && [[ " ${archs[*]} " =~ ${current} ]]; then
  docker tag "${base}:${tag}" envbuilder:latest
  echo "Tagged $current as ${base}:${tag} ${base}:latest!"
fi
===
+ archs=()
+ push=false
+ base=envbuilder
+ tag=
++ go env GOARCH
+ current=amd64
+ '[' 0 -eq 0 ']'
+ echo 'No architectures specified. Defaulting to amd64...'
No architectures specified. Defaulting to amd64...
+ archs=("$current")
+ [[ -z '' ]]
++ ./version.sh
/usr/bin/bash: line 34: ./version.sh: No such file or directory
+ tag=
```