### PR TITLE
fix: use Lchown to prevent erroring on broken symlinks

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -815,7 +815,7 @@ func run(ctx context.Context, opts options.Options, execArgs *execArgsInfo) erro
 			if err != nil {
 				return err
 			}
-			return os.Chown(path, execArgs.UserInfo.uid, execArgs.UserInfo.gid)
+			return os.Lchown(path, execArgs.UserInfo.uid, execArgs.UserInfo.gid)
 		}); chownErr != nil {
 			opts.Logger(log.LevelError, "chown %q: %s", execArgs.UserInfo.user.HomeDir, chownErr.Error())
 			endStage("⚠️ Failed to the ownership of the workspace, you may need to fix this manually!")
@@ -832,7 +832,7 @@ func run(ctx context.Context, opts options.Options, execArgs *execArgsInfo) erro
 			if err != nil {
 				return err
 			}
-			return os.Chown(path, execArgs.UserInfo.uid, execArgs.UserInfo.gid)
+			return os.Lchown(path, execArgs.UserInfo.uid, execArgs.UserInfo.gid)
 		}); chownErr != nil {
 			opts.Logger(log.LevelError, "chown %q: %s", execArgs.UserInfo.user.HomeDir, chownErr.Error())
 			endStage("⚠️ Failed to update ownership of %s, you may need to fix this manually!", execArgs.UserInfo.user.HomeDir)


### PR DESCRIPTION
It's better to use [Lchown](https://pkg.go.dev/os#Lchown) instead [Chown](https://pkg.go.dev/os#Chown) because:
1. there are dummy/broken symlinks may use in repository. For example, we use dummy/broken symlinks for tests.
2. some software create dummy symlinks in users home. For example, nix with options `--no-channel-add` create broken symlinks:
```
root ➜ / $ ls -l /home/vscode/.nix-defexpr/channels_root
lrwxrwxrwx 1 root root 44 Dec  3 15:34 /home/vscode/.nix-defexpr/channels_root -> /nix/var/nix/profiles/per-user/root/channels
root ➜ / $  ls -l  /nix/var/nix/profiles/per-user/root/channels
ls: cannot access '/nix/var/nix/profiles/per-user/root/channels': No such file or directory
```
Without this PR envbuilder fails with error:
```
chown "/home/vscode": chown /home/vscode/.nix-defexpr/channels_root: no such file or directory
```