### PR TITLE
refactor(testutil): refactor registrytest

### DIFF
--- a/devcontainer/devcontainer_test.go
+++ b/devcontainer/devcontainer_test.go
@@ -231,7 +231,7 @@ func TestUserFrom(t *testing.T) {
 		}})
 		require.NoError(t, err)
 
-		parsed, err := url.Parse(registry)
+		parsed, err := url.Parse("http://" + registry)
 		require.NoError(t, err)
 		parsed.Path = "coder/test:latest"
 		ref, err := name.ParseReference(strings.TrimPrefix(parsed.String(), "http://"))
@@ -306,7 +306,7 @@ func TestUserFrom(t *testing.T) {
 				},
 			}})
 			require.NoError(t, err)
-			parsed, err := url.Parse(registry)
+			parsed, err := url.Parse("http://" + registry)
 			require.NoError(t, err)
 			parsed.Path = "coder/test:" + tag
 			ref, err := name.ParseReference(strings.TrimPrefix(parsed.String(), "http://"))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -2507,14 +2506,8 @@ type setupInMemoryRegistryOpts struct {
 
 func setupInMemoryRegistry(t *testing.T, opts setupInMemoryRegistryOpts) string {
 	t.Helper()
-	tempDir := t.TempDir()
-	regHandler := registry.New(registry.WithBlobHandler(registry.NewDiskBlobHandler(tempDir)))
-	authHandler := mwtest.BasicAuthMW(opts.Username, opts.Password)(regHandler)
-	regSrv := httptest.NewServer(authHandler)
-	t.Cleanup(func() { regSrv.Close() })
-	regSrvURL, err := url.Parse(regSrv.URL)
-	require.NoError(t, err)
-	return fmt.Sprintf("localhost:%s", regSrvURL.Port())
+	regSrv := registrytest.New(t, mwtest.BasicAuthMW(opts.Username, opts.Password))
+	return regSrv
 }
 
 // TestMain runs before all tests to build the envbuilder image.


### PR DESCRIPTION
Refactors registrytest to a form that can be used by both envbuilder and terraform-provider-envbuilder.
Also fixes an issue with `url.Parse` incorrectly interpreting the scheme of `host:port` and attempting to push an image to Docker hub.