### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The easiest way to get started is by running the `envbuilder` Docker container t
 > **Note**: The `/tmp/envbuilder` directory persists demo data between commands. You can choose a different directory if needed.
 
 ```bash
-docker run -it --rm
-    -v /tmp/envbuilder:/workspaces
-    -e ENVBUILDER_GIT_URL=https://github.com/coder/envbuilder-starter-devcontainer
-    -e ENVBUILDER_INIT_SCRIPT=bash
+docker run -it --rm \
+    -v /tmp/envbuilder:/workspaces \
+    -e ENVBUILDER_GIT_URL=https://github.com/coder/envbuilder-starter-devcontainer \
+    -e ENVBUILDER_INIT_SCRIPT=bash \
     ghcr.io/coder/envbuilder
 ```
 
@@ -76,9 +76,9 @@ else
 fi
 
 # Run envbuilder with the setup script
-docker run -it --rm
-  -v ./:/some-dir
-  -e ENVBUILDER_SETUP_SCRIPT=/some-dir/init.sh
+docker run -it --rm \
+  -v ./:/some-dir \
+  -e ENVBUILDER_SETUP_SCRIPT=/some-dir/init.sh \
   ...
 ```
 


### PR DESCRIPTION
Missing end-of-line \ 'escape character' to 'join' the lines, making the example less useful.