### PR TITLE
feat: add git clone with thinpack option to support self hosted azure devops

### DIFF
--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -27,7 +27,7 @@
 | `--git-url` | `ENVBUILDER_GIT_URL` |  | The URL of a Git repository containing a Devcontainer or Docker image to clone. This is optional. |
 | `--git-clone-depth` | `ENVBUILDER_GIT_CLONE_DEPTH` |  | The depth to use when cloning the Git repository. |
 | `--git-clone-single-branch` | `ENVBUILDER_GIT_CLONE_SINGLE_BRANCH` |  | Clone only a single branch of the Git repository. |
-| `--git-clone-thinpack` | `ENVBUILDER_GIT_CLONE_THINPACK` |  | Git clone with thin pack compatibility enabled, ensuring that even when thin pack compatibility is activated, it will not be turned on for the domain dev.zaure.com.  |
+| `--git-clone-thinpack` | `ENVBUILDER_GIT_CLONE_THINPACK` | `true` | Git clone with thin pack compatibility enabled, ensuring that even when thin pack compatibility is activated,it will not be turned on for the domain dev.zaure.com. |
 | `--git-username` | `ENVBUILDER_GIT_USERNAME` |  | The username to use for Git authentication. This is optional. |
 | `--git-password` | `ENVBUILDER_GIT_PASSWORD` |  | The password to use for Git authentication. This is optional. |
 | `--git-ssh-private-key-path` | `ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH` |  | Path to an SSH private key to be used for Git authentication. If this is set, then GIT_SSH_PRIVATE_KEY_BASE64 cannot be set. |

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -27,6 +27,7 @@
 | `--git-url` | `ENVBUILDER_GIT_URL` |  | The URL of a Git repository containing a Devcontainer or Docker image to clone. This is optional. |
 | `--git-clone-depth` | `ENVBUILDER_GIT_CLONE_DEPTH` |  | The depth to use when cloning the Git repository. |
 | `--git-clone-single-branch` | `ENVBUILDER_GIT_CLONE_SINGLE_BRANCH` |  | Clone only a single branch of the Git repository. |
+| `--git-clone-thinpack` | `ENVBUILDER_GIT_CLONE_THINPACK` |  | Clone with thin pack compabilities. |
 | `--git-username` | `ENVBUILDER_GIT_USERNAME` |  | The username to use for Git authentication. This is optional. |
 | `--git-password` | `ENVBUILDER_GIT_PASSWORD` |  | The password to use for Git authentication. This is optional. |
 | `--git-ssh-private-key-path` | `ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH` |  | Path to an SSH private key to be used for Git authentication. If this is set, then GIT_SSH_PRIVATE_KEY_BASE64 cannot be set. |

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -27,7 +27,7 @@
 | `--git-url` | `ENVBUILDER_GIT_URL` |  | The URL of a Git repository containing a Devcontainer or Docker image to clone. This is optional. |
 | `--git-clone-depth` | `ENVBUILDER_GIT_CLONE_DEPTH` |  | The depth to use when cloning the Git repository. |
 | `--git-clone-single-branch` | `ENVBUILDER_GIT_CLONE_SINGLE_BRANCH` |  | Clone only a single branch of the Git repository. |
-| `--git-clone-thinpack` | `ENVBUILDER_GIT_CLONE_THINPACK` |  | Clone with thin pack compabilities. |
+| `--git-clone-thinpack` | `ENVBUILDER_GIT_CLONE_THINPACK` |  | Git clone with thin pack compatibility enabled, ensuring that even when thin pack compatibility is activated, it will not be turned on for the domain dev.zaure.com.  |
 | `--git-username` | `ENVBUILDER_GIT_USERNAME` |  | The username to use for Git authentication. This is optional. |
 | `--git-password` | `ENVBUILDER_GIT_PASSWORD` |  | The password to use for Git authentication. This is optional. |
 | `--git-ssh-private-key-path` | `ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH` |  | Path to an SSH private key to be used for Git authentication. If this is set, then GIT_SSH_PRIVATE_KEY_BASE64 cannot be set. |

--- a/git/git.go
+++ b/git/git.go
@@ -54,28 +54,40 @@ func CloneRepo(ctx context.Context, logf func(string, ...any), opts CloneRepoOpt
 		return false, fmt.Errorf("parse url %q: %w", opts.RepoURL, err)
 	}
 	logf("Parsed Git URL as %q", parsed.Redacted())
-	if parsed.Hostname() == "dev.azure.com" || opts.ThinPack {
-		// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
-		// which are not fully implemented and by default are included in
-		// transport.UnsupportedCapabilities.
-		//
-		// The initial clone operations require a full download of the repository,
-		// and therefore those unsupported capabilities are not as crucial, so
-		// by removing them from that list allows for the first clone to work
-		// successfully.
-		//
-		// Additional fetches will yield issues, therefore work always from a clean
-		// clone until those capabilities are fully supported.
-		//
-		// New commits and pushes against a remote worked without any issues.
-		// See: https://github.com/go-git/go-git/issues/64
-		//
-		// This is knowingly not safe to call in parallel, but it seemed
-		// like the least-janky place to add a super janky hack.
+
+	thinPack := true
+
+	if !opts.ThinPack {
+		thinPack = false
+		logf("ThinPack options is false, Marking thin-pack as unsupported")
+	} else {
+		if parsed.Hostname() == "dev.azure.com" {
+			// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
+			// which are not fully implemented and by default are included in
+			// transport.UnsupportedCapabilities.
+			//
+			// The initial clone operations require a full download of the repository,
+			// and therefore those unsupported capabilities are not as crucial, so
+			// by removing them from that list allows for the first clone to work
+			// successfully.
+			//
+			// Additional fetches will yield issues, therefore work always from a clean
+			// clone until those capabilities are fully supported.
+			//
+			// New commits and pushes against a remote worked without any issues.
+			// See: https://github.com/go-git/go-git/issues/64
+			//
+			// This is knowingly not safe to call in parallel, but it seemed
+			// like the least-janky place to add a super janky hack.
+			thinPack = false
+			logf("Workaround for Azure DevOps: marking thin-pack as unsupported")
+		}
+	}
+
+	if !thinPack {
 		transport.UnsupportedCapabilities = []capability.Capability{
 			capability.ThinPack,
 		}
-		logf("Workaround for Azure DevOps: marking thin-pack as unsupported")
 	}
 
 	err = opts.Storage.MkdirAll(opts.Path, 0o755)

--- a/git/git.go
+++ b/git/git.go
@@ -60,28 +60,26 @@ func CloneRepo(ctx context.Context, logf func(string, ...any), opts CloneRepoOpt
 	if !opts.ThinPack {
 		thinPack = false
 		logf("ThinPack options is false, Marking thin-pack as unsupported")
-	} else {
-		if parsed.Hostname() == "dev.azure.com" {
-			// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
-			// which are not fully implemented and by default are included in
-			// transport.UnsupportedCapabilities.
-			//
-			// The initial clone operations require a full download of the repository,
-			// and therefore those unsupported capabilities are not as crucial, so
-			// by removing them from that list allows for the first clone to work
-			// successfully.
-			//
-			// Additional fetches will yield issues, therefore work always from a clean
-			// clone until those capabilities are fully supported.
-			//
-			// New commits and pushes against a remote worked without any issues.
-			// See: https://github.com/go-git/go-git/issues/64
-			//
-			// This is knowingly not safe to call in parallel, but it seemed
-			// like the least-janky place to add a super janky hack.
-			thinPack = false
-			logf("Workaround for Azure DevOps: marking thin-pack as unsupported")
-		}
+	} else if parsed.Hostname() == "dev.azure.com" {
+		// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
+		// which are not fully implemented and by default are included in
+		// transport.UnsupportedCapabilities.
+		//
+		// The initial clone operations require a full download of the repository,
+		// and therefore those unsupported capabilities are not as crucial, so
+		// by removing them from that list allows for the first clone to work
+		// successfully.
+		//
+		// Additional fetches will yield issues, therefore work always from a clean
+		// clone until those capabilities are fully supported.
+		//
+		// New commits and pushes against a remote worked without any issues.
+		// See: https://github.com/go-git/go-git/issues/64
+		//
+		// This is knowingly not safe to call in parallel, but it seemed
+		// like the least-janky place to add a super janky hack.
+		thinPack = false
+		logf("Workaround for Azure DevOps: marking thin-pack as unsupported")
 	}
 
 	if !thinPack {

--- a/git/git.go
+++ b/git/git.go
@@ -37,6 +37,7 @@ type CloneRepoOptions struct {
 	Progress     sideband.Progress
 	Insecure     bool
 	SingleBranch bool
+	ThinPack     bool
 	Depth        int
 	CABundle     []byte
 	ProxyOptions transport.ProxyOptions
@@ -53,7 +54,7 @@ func CloneRepo(ctx context.Context, logf func(string, ...any), opts CloneRepoOpt
 		return false, fmt.Errorf("parse url %q: %w", opts.RepoURL, err)
 	}
 	logf("Parsed Git URL as %q", parsed.Redacted())
-	if parsed.Hostname() == "dev.azure.com" {
+	if parsed.Hostname() == "dev.azure.com" || opts.ThinPack {
 		// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
 		// which are not fully implemented and by default are included in
 		// transport.UnsupportedCapabilities.
@@ -347,6 +348,7 @@ func CloneOptionsFromOptions(logf func(string, ...any), options options.Options)
 		Storage:      options.Filesystem,
 		Insecure:     options.Insecure,
 		SingleBranch: options.GitCloneSingleBranch,
+		ThinPack:     options.GitCloneThinPack,
 		Depth:        int(options.GitCloneDepth),
 		CABundle:     caBundle,
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -106,6 +106,8 @@ type Options struct {
 	GitCloneDepth int64
 	// GitCloneSingleBranch clone only a single branch of the Git repository.
 	GitCloneSingleBranch bool
+	// GitCloneThinPack clone with thin pack compabilities. This is optional.
+	GitCloneThinPack bool
 	// GitUsername is the username to use for Git authentication. This is
 	// optional.
 	GitUsername string
@@ -374,6 +376,12 @@ func (o *Options) CLI() serpent.OptionSet {
 			Env:         WithEnvPrefix("GIT_CLONE_SINGLE_BRANCH"),
 			Value:       serpent.BoolOf(&o.GitCloneSingleBranch),
 			Description: "Clone only a single branch of the Git repository.",
+		},
+		{
+			Flag:        "git-clone-thinpack",
+			Env:         WithEnvPrefix("GIT_CLONE_THINPACK"),
+			Value:       serpent.BoolOf(&o.GitCloneThinPack),
+			Description: "Clone with thin pack compabilities.",
 		},
 		{
 			Flag:        "git-username",

--- a/options/options.go
+++ b/options/options.go
@@ -378,11 +378,13 @@ func (o *Options) CLI() serpent.OptionSet {
 			Description: "Clone only a single branch of the Git repository.",
 		},
 		{
-			Flag:        "git-clone-thinpack",
-			Env:         WithEnvPrefix("GIT_CLONE_THINPACK"),
-			Value:       serpent.BoolOf(&o.GitCloneThinPack),
-			Default:     "true",
-			Description: "Git clone with thin pack compatibility enable.",
+			Flag:    "git-clone-thinpack",
+			Env:     WithEnvPrefix("GIT_CLONE_THINPACK"),
+			Value:   serpent.BoolOf(&o.GitCloneThinPack),
+			Default: "true",
+			Description: "Git clone with thin pack compatibility enabled, " +
+				"ensuring that even when thin pack compatibility is activated," +
+				"it will not be turned on for the domain dev.zaure.com.",
 		},
 		{
 			Flag:        "git-username",

--- a/options/options.go
+++ b/options/options.go
@@ -381,7 +381,8 @@ func (o *Options) CLI() serpent.OptionSet {
 			Flag:        "git-clone-thinpack",
 			Env:         WithEnvPrefix("GIT_CLONE_THINPACK"),
 			Value:       serpent.BoolOf(&o.GitCloneThinPack),
-			Description: "Clone with thin pack compabilities.",
+			Default:     "true",
+			Description: "Git clone with thin pack compatibility enable.",
 		},
 		{
 			Flag:        "git-username",

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -38,31 +38,39 @@ func TestEnvOptionParsing(t *testing.T) {
 		t.Run("lowercase", func(t *testing.T) {
 			t.Setenv(options.WithEnvPrefix("SKIP_REBUILD"), "true")
 			t.Setenv(options.WithEnvPrefix("GIT_CLONE_SINGLE_BRANCH"), "false")
+			t.Setenv(options.WithEnvPrefix("GIT_CLONE_THINPACK"), "false")
 			o := runCLI()
 			require.True(t, o.SkipRebuild)
 			require.False(t, o.GitCloneSingleBranch)
+			require.False(t, o.GitCloneThinPack)
 		})
 
 		t.Run("uppercase", func(t *testing.T) {
 			t.Setenv(options.WithEnvPrefix("SKIP_REBUILD"), "TRUE")
 			t.Setenv(options.WithEnvPrefix("GIT_CLONE_SINGLE_BRANCH"), "FALSE")
+			t.Setenv(options.WithEnvPrefix("GIT_CLONE_THINPACK"), "FALSE")
 			o := runCLI()
 			require.True(t, o.SkipRebuild)
 			require.False(t, o.GitCloneSingleBranch)
+			require.False(t, o.GitCloneThinPack)
 		})
 
 		t.Run("numeric", func(t *testing.T) {
 			t.Setenv(options.WithEnvPrefix("SKIP_REBUILD"), "1")
 			t.Setenv(options.WithEnvPrefix("GIT_CLONE_SINGLE_BRANCH"), "0")
+			t.Setenv(options.WithEnvPrefix("GIT_CLONE_THINPACK"), "0")
 			o := runCLI()
 			require.True(t, o.SkipRebuild)
 			require.False(t, o.GitCloneSingleBranch)
+			require.False(t, o.GitCloneThinPack)
 		})
 
 		t.Run("empty", func(t *testing.T) {
 			t.Setenv(options.WithEnvPrefix("GIT_CLONE_SINGLE_BRANCH"), "")
+			t.Setenv(options.WithEnvPrefix("GIT_CLONE_THINPACK"), "")
 			o := runCLI()
 			require.False(t, o.GitCloneSingleBranch)
+			require.False(t, o.GitCloneThinPack)
 		})
 	})
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -70,7 +70,7 @@ func TestEnvOptionParsing(t *testing.T) {
 			t.Setenv(options.WithEnvPrefix("GIT_CLONE_THINPACK"), "")
 			o := runCLI()
 			require.False(t, o.GitCloneSingleBranch)
-			require.False(t, o.GitCloneThinPack)
+			require.True(t, o.GitCloneThinPack)
 		})
 	})
 }

--- a/options/testdata/options.golden
+++ b/options/testdata/options.golden
@@ -99,8 +99,10 @@ OPTIONS:
       --git-clone-single-branch bool, $ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
           Clone only a single branch of the Git repository.
 
-      --git-clone-thinpack bool, $ENVBUILDER_GIT_CLONE_THINPACK
-          Git clone with thin pack compatibility enable.
+      --git-clone-thinpack bool, $ENVBUILDER_GIT_CLONE_THINPACK (default: true)
+          Git clone with thin pack compatibility enabled, ensuring that even
+          when thin pack compatibility is activated,it will not be turned on for
+          the domain dev.zaure.com.
 
       --git-http-proxy-url string, $ENVBUILDER_GIT_HTTP_PROXY_URL
           The URL for the HTTP proxy. This is optional.

--- a/options/testdata/options.golden
+++ b/options/testdata/options.golden
@@ -100,7 +100,7 @@ OPTIONS:
           Clone only a single branch of the Git repository.
 
       --git-clone-thinpack bool, $ENVBUILDER_GIT_CLONE_THINPACK
-          Clone with thin pack compabilities.
+          Git clone with thin pack compatibility enable.
 
       --git-http-proxy-url string, $ENVBUILDER_GIT_HTTP_PROXY_URL
           The URL for the HTTP proxy. This is optional.

--- a/options/testdata/options.golden
+++ b/options/testdata/options.golden
@@ -99,6 +99,9 @@ OPTIONS:
       --git-clone-single-branch bool, $ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
           Clone only a single branch of the Git repository.
 
+      --git-clone-thinpack bool, $ENVBUILDER_GIT_CLONE_THINPACK
+          Clone with thin pack compabilities.
+
       --git-http-proxy-url string, $ENVBUILDER_GIT_HTTP_PROXY_URL
           The URL for the HTTP proxy. This is optional.
 


### PR DESCRIPTION
The program uses only the hostname to address the issue of requiring thin pack to perform a git clone operation on Azure DevOps, as shown in the code snippet below.

https://github.com/coder/envbuilder/blob/d045c1ce27a5995ac60409bd48ad8e90861b6bfd/git/git.go#L56-L78

However, since Azure DevOps supports self-hosted servers, the hostname may not necessarily be dev.azure.com. Therefore, it is desired to add a command-line option to enable this functionality.